### PR TITLE
Fix header layout and navigation paths

### DIFF
--- a/src/components/PostHeader.astro
+++ b/src/components/PostHeader.astro
@@ -1,5 +1,5 @@
 ---
-import { Image } from "astro:assets";
+import { formatDate } from "../ts/utils";
 
 interface Props {
   title: string;
@@ -12,41 +12,25 @@ interface Props {
     alt: string;
   };
 }
+
+const { title, description, date, category, designers, cover } = Astro.props as Props;
 ---
 
-<header class="page-header">
-  445645
-  <!-- <div class="absolute inset-0 overflow-hidden">
-    <img
-      src={Astro.props.cover.src}
-      alt={Astro.props.cover.alt}
-      class="w-full h-full object-cover"
-    />
-    <div class="header-overlay"></div>
-  </div>
-  
-  <div class="header-content">
-    <div class="text-white space-y-4">
-      <div class="flex items-center gap-4">
-        <span class="tag">{Astro.props.category}</span>
-        <time class="text-sm">
-          {new Date(Astro.props.date).toLocaleDateString('zh-TW', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })}
-        </time>
-      </div>
-      <h1 class="text-4xl md:text-5xl font-bold">{title}</h1>
-      <p class="text-lg md:text-xl text-gray-200 max-w-2xl">{description}</p>
-      <div class="flex items-center gap-2 text-sm">
-        <span>設計師：</span>
-        <div class="flex gap-2">
-          {designers.map((designer: string) => (
-            <span class="tag-secondary">{designer}</span>
-          ))}
-        </div>
-      </div>
+<header class="relative mb-8 h-64 md:h-96">
+  <img src={cover.src} alt={cover.alt} class="absolute inset-0 w-full h-full object-cover" />
+  <div class="absolute inset-0 bg-black/50 flex flex-col justify-center items-center text-white px-4 text-center">
+    <div class="mb-2 flex items-center gap-4">
+      <span class="px-3 py-1 bg-primary rounded-full text-xs">{category}</span>
+      <time class="text-xs">{formatDate(new Date(date))}</time>
     </div>
-  </div> -->
-</header> 
+    <h1 class="text-3xl md:text-4xl font-bold mb-2">{title}</h1>
+    <p class="max-w-2xl">{description}</p>
+    {designers.length > 0 && (
+      <div class="mt-4 flex flex-wrap gap-2">
+        {designers.map((designer: string) => (
+          <span class="bg-primary/70 px-2 py-1 rounded">{designer}</span>
+        ))}
+      </div>
+    )}
+  </div>
+</header>

--- a/src/data/navdata.ts
+++ b/src/data/navdata.ts
@@ -1,19 +1,19 @@
 const navData = [
   {
     name: "About",
-    path: "about"
+    path: "/about"
   },
   {
     name: "Project",
-    path: "project"
+    path: "/project"
   },
   {
     name: "Blog",
-    path: "blog"
+    path: "/blog"
   },
   {
     name: "Contact",
-    path: "contact"
+    path: "/contact"
   }
 ]
 


### PR DESCRIPTION
## Summary
- correct navigation links by prefixing with slashes
- implement PostHeader with proper markup

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693a4310ac83248ad1a067c11cb3ed