### PR TITLE
Define Astro.props interfaces

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -7,6 +7,16 @@ import CategorySection from '../../components/CategorySection.astro';
 // import
 import { getCollection, type CollectionEntry } from 'astro:content';
 
+interface BlogPageProps {
+  page: {
+    data: CollectionEntry<'posts'>[];
+    url: {
+      prev?: string;
+      next?: string;
+    };
+  };
+}
+
 // export
 export const prerender = true;
 
@@ -19,7 +29,7 @@ export async function getStaticPaths({ paginate }: { paginate: any}){
   });
 }
 
-const { page } = Astro.props as any;
+const { page } = Astro.props as BlogPageProps;
 ---
 
 <MainLayout>

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import PostLayout from '../../layouts/PostLayout.astro';
 import { slugify } from '../../ts/utils';
 
@@ -13,7 +13,11 @@ export async function getStaticPaths() {
   }));
 }
 
-const { post } = Astro.props;
+interface PostPageProps {
+  post: CollectionEntry<'posts'>;
+}
+
+const { post } = Astro.props as PostPageProps;
 
 if (!post) {
   return Astro.redirect('/404');

--- a/src/pages/category/[category].astro
+++ b/src/pages/category/[category].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import MainLayout from '../../layouts/MainLayout.astro';
 import PostCard from '../../components/PostCard.astro';
 import { slugify } from '../../ts/utils';
@@ -28,7 +28,12 @@ export async function getStaticPaths() {
   });
 }
 
-const { category, posts } = Astro.props;
+interface CategoryPageProps {
+  category: string;
+  posts: CollectionEntry<'posts'>[];
+}
+
+const { category, posts } = Astro.props as CategoryPageProps;
 const title = `${category.charAt(0).toUpperCase() + category.slice(1)} Category Posts`;
 const description = `Check all posts in ${category} category`;
 ---

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -8,6 +8,16 @@ import Pagination from '../../components/Pagination.astro';
 // import
 import { getCollection, type CollectionEntry } from 'astro:content';
 
+interface ProjectListProps {
+  page: {
+    data: CollectionEntry<'projects'>[];
+    url: {
+      prev?: string;
+      next?: string;
+    };
+  };
+}
+
 // export
 export const prerender = true;
 
@@ -20,7 +30,7 @@ export async function getStaticPaths({ paginate }: { paginate: any}){
   });
 }
 
-const { page } = Astro.props;
+const { page } = Astro.props as ProjectListProps;
 
 ---
 

--- a/src/pages/project/[project].astro
+++ b/src/pages/project/[project].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import { slugify, formatDate } from '../../ts/utils';
 import MainLayout from '../../layouts/MainLayout.astro';
 
@@ -16,7 +16,11 @@ export async function getStaticPaths() {
   }));
 }
 
-const { project } = Astro.props;
+interface ProjectPageProps {
+  project: CollectionEntry<'projects'>;
+}
+
+const { project } = Astro.props as ProjectPageProps;
 const { data, id } = project;
 
 const getRelatedProjects = async () => {

--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, type CollectionEntry } from "astro:content";
 import MainLayout from "../../layouts/MainLayout.astro";
 import Link from "../../components/Link.astro";
 import { slugify} from "../../ts/utils";
@@ -33,7 +33,12 @@ export async function getStaticPaths() {
   });
 }
 
-const { tag, projects } = Astro.props;
+interface TagPageProps {
+  tag: string;
+  projects: CollectionEntry<'projects'>[];
+}
+
+const { tag, projects } = Astro.props as TagPageProps;
 const displayTag = tag;
 ---
 


### PR DESCRIPTION
## Summary
- create props interfaces for Astro pages
- use defined interfaces in place of `any`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe85affe08324a88059d5fbce67a5