### PR TITLE
refactor: centralize scroll utilities

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -99,34 +99,6 @@ const { page } = Astro.props as BlogPageProps;
   </section>
 </MainLayout>
 
-<script>
-  // 回到頂部功能
-  document.getElementById('backToTop')?.addEventListener('click', () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  });
-
-  // 展開全部功能
-  let isExpanded = false;
-  document.getElementById('expandAll')?.addEventListener('click', () => {
-    const button = document.getElementById('expandAll');
-    if (button) {
-      isExpanded = !isExpanded;
-      button.textContent = isExpanded ? '收合全部' : '展開全部';
-      
-      // 這裡可以根據需求添加展開/收合的邏輯
-      const details = document.querySelectorAll('details');
-      details.forEach(detail => {
-        detail.open = isExpanded;
-      });
-    }
-  });
-
-  // 滾動到底部功能
-  document.getElementById('scrollToBottom')?.addEventListener('click', () => {
-    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
-  });
-</script>
-
 <style>
 
 

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -163,31 +163,11 @@ const { Content, headings } = await post.render();
 </PostLayout>
 
 <script>
-  // back to top function
-  document.getElementById('backToTop')?.addEventListener('click', () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  });
+  import { setupScrollToTop, setupExpandAll, setupScrollToBottom } from '../../ts/scroll-utils';
 
-  // expand all function
-  let isExpanded = false;
-  document.getElementById('expandAll')?.addEventListener('click', () => {
-    const button = document.getElementById('expandAll');
-    if (button) {
-      isExpanded = !isExpanded;
-      button.textContent = isExpanded ? 'Collapse All' : 'Expand All';
-      
-      // here you can add the logic for expand/collapse
-      const details = document.querySelectorAll('details');
-      details.forEach(detail => {
-        detail.open = isExpanded;
-      });
-    }
-  });
-
-  // scroll to bottom function
-  document.getElementById('scrollToBottom')?.addEventListener('click', () => {
-    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
-  });
+  setupScrollToTop('backToTop');
+  setupExpandAll('expandAll', 'Expand All', 'Collapse All');
+  setupScrollToBottom('scrollToBottom');
 
   // smooth scroll to anchor
   document.querySelectorAll('.table-of-contents a').forEach(link => {

--- a/src/pages/project/[project].astro
+++ b/src/pages/project/[project].astro
@@ -125,31 +125,10 @@ const coverData = typeof data.cover === 'string' && data.cover
 </MainLayout>
 
 <script>
-  // back to top function
-  document.getElementById('backToTop')?.addEventListener('click', () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  });
+  import { setupScrollToTop, setupScrollToBottom } from '../../ts/scroll-utils';
 
-  // expand all function
-  let isExpanded = false;
-  document.getElementById('expandAll')?.addEventListener('click', () => {
-    const button = document.getElementById('expandAll');
-    if (button) {
-      isExpanded = !isExpanded;
-      button.textContent = isExpanded ? 'Collapse All' : 'Expand All';
-      
-      // here you can add the logic for expand/collapse
-      const details = document.querySelectorAll('details');
-      details.forEach(detail => {
-        detail.open = isExpanded;
-      });
-    }
-  });
-
-  // scroll to bottom function
-  document.getElementById('scrollToBottom')?.addEventListener('click', () => {
-    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
-  });
+  setupScrollToTop('backToTop');
+  setupScrollToBottom('scrollToBottom');
 </script>
 
 <style>

--- a/src/ts/scroll-utils.ts
+++ b/src/ts/scroll-utils.ts
@@ -1,0 +1,34 @@
+export function setupScrollToTop(id: string = 'backToTop'): void {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+}
+
+export function setupScrollToBottom(id: string = 'scrollToBottom'): void {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.addEventListener('click', () => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+  });
+}
+
+export function setupExpandAll(
+  id: string = 'expandAll',
+  expandText: string = 'Expand All',
+  collapseText: string = 'Collapse All'
+): void {
+  const button = document.getElementById(id);
+  if (!button) return;
+  let isExpanded = false;
+  button.addEventListener('click', () => {
+    isExpanded = !isExpanded;
+    button.textContent = isExpanded ? collapseText : expandText;
+    const details = document.querySelectorAll('details');
+    details.forEach(detail => {
+      (detail as HTMLDetailsElement).open = isExpanded;
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- add reusable scroll helpers for top, bottom, and expand-all behaviour
- import helpers in blog post and project pages; drop unused script on blog list

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails to fetch web fonts but build completes)


------
https://chatgpt.com/codex/tasks/task_e_68a1eee63f088324bb945cabd5c99090