### PR TITLE
feat: add reusable category page template

### DIFF
--- a/src/pages/_templates/CategoryPage.astro
+++ b/src/pages/_templates/CategoryPage.astro
@@ -1,0 +1,92 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+import MainLayout from '../../layouts/MainLayout.astro';
+import { slugify } from '../../ts/utils';
+
+export function createGetStaticPaths(collection: string) {
+  return async function getStaticPaths() {
+    const allItems = await getCollection(collection, ({ data }) => {
+      return !data.draft;
+    });
+
+    const uniqueCategories = [...new Set(allItems.map(item => item.data.category))];
+
+    return uniqueCategories.map(category => {
+      const filteredItems = allItems.filter(item => item.data.category === category);
+      return {
+        params: { category: slugify(category) },
+        props: {
+          items: filteredItems,
+          category
+        }
+      };
+    });
+  };
+}
+
+interface CategoryPageProps<T = any> {
+  category: string;
+  items: CollectionEntry<T>[];
+  /** Display name used in title and descriptions, e.g. "文章" or "專案" */
+  itemLabel: string;
+  /** Name of the prop passed to CardComponent, e.g. "post" or "project" */
+  itemPropName: string;
+  CardComponent: any;
+  CategoryListComponent: any;
+  PopularComponent: any;
+  /** Link to view all items of this type */
+  allHref: string;
+}
+
+const {
+  category,
+  items,
+  itemLabel,
+  itemPropName,
+  CardComponent,
+  CategoryListComponent,
+  PopularComponent,
+  allHref
+} = Astro.props as CategoryPageProps;
+
+const title = `${category} ${itemLabel}分類`;
+const description = `查看所有 ${category} 分類的${itemLabel}`;
+---
+
+<MainLayout title={title} description={description}>
+  <section
+    class="container mx-auto px-4 py-16"
+    aria-label={`分類${itemLabel}列表`}
+  >
+    <div class="flex gap-8 max-w-7xl mx-auto">
+      <!-- 左側邊欄 -->
+      <aside class="w-64 shrink-0 hidden lg:block">
+        <div class="sticky-navbar-safe space-y-8">
+          <!-- 分類列表 -->
+          <CategoryListComponent currentCategory={category} />
+
+          <!-- 熱門{itemLabel} -->
+          <PopularComponent limit={5} />
+        </div>
+      </aside>
+
+      <!-- 主要內容區 -->
+      <div class="flex-grow mt-8">
+        <h1 class="text-3xl font-bold mb-6">{title}</h1>
+        <p class="mb-8">{description}</p>
+
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {items.map((item) => (
+            <CardComponent {...{ [itemPropName]: item }} />
+          ))}
+        </div>
+
+        <div class="mt-12 text-center">
+          <a href={allHref} class="px-6 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors">
+            所有{itemLabel}
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</MainLayout>

--- a/src/pages/blog/category/[category].astro
+++ b/src/pages/blog/category/[category].astro
@@ -1,78 +1,22 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
-import MainLayout from '../../../layouts/MainLayout.astro';
+import CategoryPage, { createGetStaticPaths } from '../../_templates/CategoryPage.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import CategorySection from '../../../components/blog/CategorySection.astro';
 import PopularPosts from '../../../components/blog/PopularPosts.astro';
-import { slugify } from '../../../ts/utils';
 
 export const prerender = true;
+export const getStaticPaths = createGetStaticPaths('posts');
 
-export async function getStaticPaths() {
-  const allPosts = await getCollection('posts', ({ data }) => {
-    return !data.draft;
-  });
-
-  const uniqueCategories = [...new Set(allPosts.map(post => post.data.category))];
-
-  return uniqueCategories.map(category => {
-    const filteredPosts = allPosts.filter(post => 
-      post.data.category === category
-    );
-    return {
-      params: { category: slugify(category) },
-      props: { 
-        posts: filteredPosts,
-        category: category 
-      }
-    };
-  });
-}
-
-interface CategoryPageProps {
-  category: string;
-  posts: CollectionEntry<'posts'>[];
-}
-
-const { category, posts } = Astro.props as CategoryPageProps;
-const title = `${category} 文章分類`;
-const description = `查看所有 ${category} 分類的文章`;
+const { category, items } = Astro.props;
 ---
 
-<MainLayout title={title} description={description}>
-  <section 
-    class="container mx-auto px-4 py-16"
-    aria-label="分類文章列表"
-  >
-    <div class="flex gap-8 max-w-7xl mx-auto">
-      <!-- 左側邊欄 -->
-      <aside class="w-64 shrink-0 hidden lg:block">
-        <div class="sticky-navbar-safe space-y-8">
-          <!-- 分類列表 -->
-          <CategorySection currentCategory={category} />
-
-          <!-- 熱門文章 -->
-          <PopularPosts limit={5} />
-        </div>
-      </aside>
-
-      <!-- 主要內容區 -->
-      <div class="flex-grow mt-8">
-        <h1 class="text-3xl font-bold mb-6">{title}</h1>
-        <p class="mb-8">{description}</p>
-
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {posts.map((post) => (
-            <PostCard post={post} />
-          ))}
-        </div>
-
-        <div class="mt-12 text-center">
-          <a href="/blog" class="px-6 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors">
-            所有文章
-          </a>
-        </div>
-      </div>
-    </div>
-  </section>
-</MainLayout> 
+<CategoryPage
+  category={category}
+  items={items}
+  itemLabel="文章"
+  itemPropName="post"
+  CardComponent={PostCard}
+  CategoryListComponent={CategorySection}
+  PopularComponent={PopularPosts}
+  allHref="/blog"
+/>

--- a/src/pages/project/category/[category].astro
+++ b/src/pages/project/category/[category].astro
@@ -1,78 +1,22 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
-import MainLayout from '../../../layouts/MainLayout.astro';
+import CategoryPage, { createGetStaticPaths } from '../../_templates/CategoryPage.astro';
 import ProjectCard from '../../../components/project/ProjectCard.astro';
 import ProjectCategoryList from '../../../components/project/ProjectCategoryList.astro';
 import PopularProjects from '../../../components/project/PopularProjects.astro';
-import { slugify } from '../../../ts/utils';
 
 export const prerender = true;
+export const getStaticPaths = createGetStaticPaths('projects');
 
-export async function getStaticPaths() {
-  const allProjects = await getCollection('projects', ({ data }) => {
-    return !data.draft;
-  });
-
-  const uniqueCategories = [...new Set(allProjects.map(project => project.data.category))];
-
-  return uniqueCategories.map(category => {
-    const filteredProjects = allProjects.filter(project => 
-      project.data.category === category
-    );
-    return {
-      params: { category: slugify(category) },
-      props: { 
-        projects: filteredProjects,
-        category: category 
-      }
-    };
-  });
-}
-
-interface ProjectCategoryPageProps {
-  category: string;
-  projects: CollectionEntry<'projects'>[];
-}
-
-const { category, projects } = Astro.props as ProjectCategoryPageProps;
-const title = `${category} 專案分類`;
-const description = `查看所有 ${category} 分類的專案`;
+const { category, items } = Astro.props;
 ---
 
-<MainLayout title={title} description={description}>
-  <section 
-    class="container mx-auto px-4 py-16"
-    aria-label="分類專案列表"
-  >
-    <div class="flex gap-8 max-w-7xl mx-auto">
-      <!-- 左側邊欄 -->
-      <aside class="w-64 shrink-0 hidden lg:block">
-        <div class="sticky-navbar-safe space-y-8">
-          <!-- 專案分類列表 -->
-          <ProjectCategoryList currentCategory={category} />
-
-          <!-- 熱門專案 -->
-          <PopularProjects limit={5} />
-        </div>
-      </aside>
-
-      <!-- 主要內容區 -->
-      <div class="flex-grow">
-        <h1 class="text-3xl font-bold mb-6">{title}</h1>
-        <p class="mb-8">{description}</p>
-
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {projects.map((project) => (
-            <ProjectCard project={project} />
-          ))}
-        </div>
-
-        <div class="mt-12 text-center">
-          <a href="/project" class="px-6 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors">
-            所有專案
-          </a>
-        </div>
-      </div>
-    </div>
-  </section>
-</MainLayout> 
+<CategoryPage
+  category={category}
+  items={items}
+  itemLabel="專案"
+  itemPropName="project"
+  CardComponent={ProjectCard}
+  CategoryListComponent={ProjectCategoryList}
+  PopularComponent={PopularProjects}
+  allHref="/project"
+/>


### PR DESCRIPTION
## Summary
- extract common category logic into `_templates/CategoryPage`
- refactor blog and project category pages to use shared template

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1eb1243b08324b12ea24ed80a67e3