### PR TITLE
refactor: centralize date formatting with helper

### DIFF
--- a/src/components/blog/PopularPosts.astro
+++ b/src/components/blog/PopularPosts.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import { formatDate } from "../../ts/utils";
 
 interface Props {
   limit?: number;
@@ -30,7 +31,7 @@ const popularPosts = allPosts
             {post.data.title}
           </h3>
           <span class="text-xs text-text-muted mt-1 block opacity-70">
-            {new Date(post.data.date).toLocaleDateString()}
+            {formatDate(new Date(post.data.date))}
           </span>
         </a>
       </li>

--- a/src/components/project/PopularProjects.astro
+++ b/src/components/project/PopularProjects.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, formatDate } from "../../ts/utils";
 
 interface Props {
   limit?: number;
@@ -31,7 +31,7 @@ const popularProjects = allProjects
             {project.data.title}
           </h3>
           <span class="text-xs text-text-muted mt-1 block opacity-70">
-            {new Date(project.data.date).toLocaleDateString()}
+            {formatDate(new Date(project.data.date))}
           </span>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- use formatDate for popular posts and projects
- consolidate `toLocaleDateString` usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a35608062c8324902d9f1bd78c90f1