### PR TITLE
refactor: standardize project tag collection naming

### DIFF
--- a/src/components/common/TagClout.astro
+++ b/src/components/common/TagClout.astro
@@ -2,20 +2,29 @@
 import { getCollection } from 'astro:content';
 import { slugify } from "../../ts/utils";
 
-const allPosts = await getCollection('projects', ({ data }) => {
+interface Props {
+  showCount?: boolean;
+  collectionName?: 'projects' | 'posts';
+}
+
+const { showCount, collectionName = 'projects' } = Astro.props as Props;
+
+const allProjects = await getCollection(collectionName, ({ data }) => {
   return !data.draft;
 });
-const allCategories = allPosts.map((post) => post.data.tags?.map(tag => tag.toLowerCase())).flat().filter((tag): tag is string => Boolean(tag));
+
+const allCategories = allProjects
+  .map((project) => project.data.tags?.map(tag => tag.toLowerCase()))
+  .flat()
+  .filter((tag): tag is string => Boolean(tag));
 
 const processedCats = allCategories.reduce((acc, cat) => {
   const value = acc[cat] || 0;
   return {
     ...acc,
-    [cat]: value + 1
-  }
-}, {} as Record<string, number>)
-
-const { showCount } = Astro.props
+    [cat]: value + 1,
+  };
+}, {} as Record<string, number>);
 ---
 
 <ul class="categories">
@@ -29,3 +38,4 @@ const { showCount } = Astro.props
     ))
   }
 </ul>
+


### PR DESCRIPTION
## Summary
- refactor TagClout to use `allProjects` and `project` variable names
- allow TagClout to accept a `collectionName` prop for different content types

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3561d608483248bb965fb8aa0b75a