### PR TITLE
refactor: add paginated list template

### DIFF
--- a/src/pages/_templates/PaginatedList.astro
+++ b/src/pages/_templates/PaginatedList.astro
@@ -1,0 +1,98 @@
+---
+import MainLayout from '../../layouts/MainLayout.astro';
+import Pagination from '../../components/common/Pagination.astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export function createGetStaticPaths(collectionName: string, pageSize = 6) {
+  return async function getStaticPaths({ paginate }: { paginate: any }) {
+    const allItems = await getCollection(collectionName, ({ data }) => !data.draft);
+    return paginate(allItems, { pageSize });
+  };
+}
+
+interface PaginatedListProps<T = any> {
+  collectionName: string;
+  cardComponent: any;
+  sidebarComponents: any[];
+  page: {
+    data: CollectionEntry<T>[];
+    url: {
+      prev?: string;
+      next?: string;
+    };
+  };
+  title?: string;
+}
+
+const {
+  collectionName,
+  cardComponent: CardComponent,
+  sidebarComponents = [],
+  page,
+  title,
+} = Astro.props as PaginatedListProps;
+
+const itemPropName = collectionName.endsWith('s') ? collectionName.slice(0, -1) : 'item';
+const gridClass = collectionName === 'projects'
+  ? 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12'
+  : 'grid grid-cols-1 lg:grid-cols-2 gap-6';
+const cardWrapperClass = collectionName === 'projects'
+  ? 'bg-white dark:bg-background-secondary rounded-lg overflow-hidden shadow-dark border border-gray-100 dark:border-gray-700 hover:shadow-dark-lg transition-all duration-300'
+  : '';
+---
+
+<MainLayout {title}>
+  <section
+    class="container mx-auto px-4 py-16"
+  >
+    <div class="flex gap-8 max-w-7xl mx-auto">
+      <aside class="w-64 shrink-0 hidden lg:block">
+        <div class="sticky-navbar-safe space-y-8">
+          {sidebarComponents.map(Component => (
+            <Component />
+          ))}
+        </div>
+      </aside>
+
+      <div class="flex-grow mt-8">
+        {page && page.data?.length > 0 ? (
+          <>
+            <div class={gridClass}>
+              {page.data.map(item => (
+                cardWrapperClass ? (
+                  <div class={cardWrapperClass}>
+                    <CardComponent {...{ [itemPropName]: item }} />
+                  </div>
+                ) : (
+                  <CardComponent {...{ [itemPropName]: item }} />
+                )
+              ))}
+            </div>
+
+            <div class="my-12 flex justify-between">
+              <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
+            </div>
+          </>
+        ) : (
+          <div class="flex flex-col items-center justify-center py-20 text-text-secondary bg-background-secondary rounded-lg shadow-inner">
+            <div class="w-16 h-16 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center text-gray-400 mb-4">
+              <span class="text-2xl">!</span>
+            </div>
+            <h2 class="text-2xl font-semibold mb-2">
+              尚無{collectionName === 'posts' ? '文章' : '專案'}
+            </h2>
+            <p class="text-center max-w-md mb-8">
+              目前尚未有任何{collectionName === 'posts' ? '文章' : '專案作品'}，請稍後再查看。
+            </p>
+            <a
+              href={import.meta.env.BASE_URL}
+              class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-opacity-90 transition-colors"
+            >
+              返回首頁
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  </section>
+</MainLayout>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,100 +1,19 @@
 ---
-// component import
-import MainLayout from '../../layouts/MainLayout.astro';
+import PaginatedList, { createGetStaticPaths } from '../_templates/PaginatedList.astro';
 import PostCard from '../../components/blog/PostCard.astro';
 import CategorySection from '../../components/blog/CategorySection.astro';
 import PopularPosts from '../../components/blog/PopularPosts.astro';
-import Pagination from '../../components/common/Pagination.astro';
-import { slugify } from '../../ts/utils';
 
-// import
-import { getCollection, type CollectionEntry } from 'astro:content';
-
-interface BlogPageProps {
-  page: {
-    data: CollectionEntry<'posts'>[];
-    url: {
-      prev?: string;
-      next?: string;
-    };
-  };
-}
-
-// export
 export const prerender = true;
+export const getStaticPaths = createGetStaticPaths('posts', 6);
 
-export async function getStaticPaths({ paginate }: { paginate: any}){
-  const allPosts = await getCollection('posts', ({ data }) => {
-    return !data.draft;
-  });
-  return paginate(allPosts, {  
-    pageSize: 6,
-  });
-}
-
-const { page } = Astro.props as BlogPageProps;
+const sidebarComponents = [CategorySection, PopularPosts];
+const { page } = Astro.props;
 ---
 
-<MainLayout>
-  <section 
-    class="container mx-auto px-4 py-16"
-    aria-label="部落格列表"
-  >
-    <div class="flex gap-8 max-w-7xl mx-auto">
-      <!-- 左側邊欄 -->
-      <aside class="w-64 shrink-0 hidden lg:block">
-        <div class="sticky-navbar-safe space-y-8">
-          <!-- 分類列表 -->
-          <CategorySection />
-
-          <!-- 熱門文章 -->
-          <PopularPosts limit={5} />
-        </div>
-      </aside>
-
-      <!-- 主要內容區 -->
-      <div class="flex-grow mt-8">
-        {page && page?.data?.length > 0 ? (
-          <>
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              { page.data.map((post) => (
-                <PostCard post={post} />
-              )) }
-            </div>
-
-            <div class="my-12 flex justify-between">
-              <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
-            </div>
-          </>
-        ) : (
-          <div class="flex flex-col items-center justify-center py-20 text-text-secondary bg-background-secondary rounded-lg shadow-inner">
-            <div class="w-16 h-16 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center text-gray-400 mb-4">
-              <span class="text-2xl">!</span>
-            </div>
-            <h2 class="text-2xl font-semibold mb-2">尚無文章</h2>
-            <p class="text-center max-w-md mb-8">
-              目前尚未有任何文章，請稍後再查看。
-            </p>
-            <a 
-              href={import.meta.env.BASE_URL}
-              class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-opacity-90 transition-colors"
-            >
-              返回首頁
-            </a>
-          </div>
-        )}
-      </div>
-    </div>
-  </section>
-</MainLayout>
-
-<style>
-
-
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-</style>
+<PaginatedList
+  collectionName="posts"
+  cardComponent={PostCard}
+  sidebarComponents={sidebarComponents}
+  page={page}
+/>

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -1,92 +1,20 @@
 ---
-// component import
-import MainLayout from '../../layouts/MainLayout.astro';
-import TagClout from '../../components/common/TagClout.astro';
+import PaginatedList, { createGetStaticPaths } from '../_templates/PaginatedList.astro';
 import ProjectCard from '../../components/project/ProjectCard.astro';
-import Pagination from '../../components/common/Pagination.astro';
 import ProjectCategoryList from '../../components/project/ProjectCategoryList.astro';
 import PopularProjects from '../../components/project/PopularProjects.astro';
 
-// import
-import { getCollection, type CollectionEntry } from 'astro:content';
-
-interface ProjectListProps {
-  page: {
-    data: CollectionEntry<'projects'>[];
-    url: {
-      prev?: string;
-      next?: string;
-    };
-  };
-}
-
-// export
 export const prerender = true;
+export const getStaticPaths = createGetStaticPaths('projects', 6);
 
-export async function getStaticPaths({ paginate }: { paginate: any}){
-  const allProjects = await getCollection('projects', ({ data }) => {
-    return !data.draft;
-  });
-  return paginate(allProjects, {  
-    pageSize: 6,
-  });
-}
-
-const { page } = Astro.props as ProjectListProps;
+const sidebarComponents = [ProjectCategoryList, PopularProjects];
+const { page } = Astro.props;
 ---
 
-<MainLayout title="案例作品">
-  <section 
-    class="container mx-auto px-4 py-16"
-    aria-label="專案列表"
-  >
-    <div class="flex gap-8 max-w-7xl mx-auto">
-      <!-- 左側邊欄 -->
-      <aside class="w-64 shrink-0 hidden lg:block">
-        <div class="sticky-navbar-safe space-y-8">
-          <!-- 專案分類列表 -->
-          <ProjectCategoryList />
-
-          <!-- 熱門專案 -->
-          <PopularProjects limit={5} />
-        </div>
-      </aside>
-
-      <!-- 主要內容區 -->
-      <div class="flex-grow mt-8">
-        {page && page?.data?.length > 0 ? (
-          <>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
-              {page.data.map((project) => (
-                <div class="bg-white dark:bg-background-secondary rounded-lg overflow-hidden shadow-dark border border-gray-100 dark:border-gray-700 hover:shadow-dark-lg transition-all duration-300">
-                  <ProjectCard project={project} />
-                </div>
-              ))}
-            </div>
-            
-            <div class="my-12 flex justify-between">
-              <Pagination prevUrl={page.url.prev} nextUrl={page.url.next} />
-            </div>
-          </>
-        ) : (
-          <div class="flex flex-col items-center justify-center py-20 text-text-secondary bg-background-secondary rounded-lg shadow-inner">
-            <div class="w-16 h-16 bg-gray-200 dark:bg-gray-700 rounded-full flex items-center justify-center text-gray-400 mb-4">
-              <span class="text-2xl">!</span>
-            </div>
-            <h2 class="text-2xl font-semibold mb-2">尚無專案</h2>
-            <p class="text-center max-w-md mb-8">
-              目前尚未有任何專案作品，請稍後再查看。
-            </p>
-            <a 
-              href={import.meta.env.BASE_URL}
-              class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-opacity-90 transition-colors"
-            >
-              返回首頁
-            </a>
-          </div>
-        )}
-    </div>
-  </section>
-</MainLayout>
-
-
+<PaginatedList
+  collectionName="projects"
+  cardComponent={ProjectCard}
+  sidebarComponents={sidebarComponents}
+  page={page}
+  title="案例作品"
+/>


### PR DESCRIPTION
## Summary
- extract shared paginated list template for content collections
- use template in blog and project paginated pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a356211a9c83249583caeb6e118c65