### PR TITLE
refactor: centralize line clamp style

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -73,11 +73,4 @@ const imageAlt = image?.alt || title || "文章圖片";
     flex-direction: column;
     height: 100%;
   }
-  
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;  
-    overflow: hidden;
-  }
 </style>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -88,13 +88,3 @@ const { page } = Astro.props as BlogPageProps;
   </section>
 </MainLayout>
 
-<style>
-
-
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-</style>

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -185,13 +185,6 @@ const { Content, headings } = await post.render();
 </script>
 
 <style>
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
   .prose {
     max-width: none;
   }

--- a/src/pages/project/[project].astro
+++ b/src/pages/project/[project].astro
@@ -132,14 +132,7 @@ const coverData = typeof data.cover === 'string' && data.cover
 </script>
 
 <style>
-  .line-clamp-2 {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-  }
-
   .prose {
     max-width: none;
   }
-</style> 
+</style>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -105,6 +105,14 @@
          2xl:max-w-[1320px];
 }
 
+/* 文本截斷 */
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* 加載動畫 */
 .spinner {
   @apply w-8 h-8 border-[3px] border-transparent rounded-full


### PR DESCRIPTION
## Summary
- add global `.line-clamp-2` utility in `components.css`
- remove redundant `.line-clamp-2` style blocks from post and project pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(web font fetch failed but build completed)*

------
https://chatgpt.com/codex/tasks/task_e_68a35631dd788324a147410d2a821901