### PR TITLE
refactor: extract reusable category list component

### DIFF
--- a/src/components/blog/CategorySection.astro
+++ b/src/components/blog/CategorySection.astro
@@ -1,46 +1,15 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import CategoryList from '../common/CategoryList.astro';
 
 interface Props {
   currentCategory?: string;
 }
 
 const { currentCategory } = Astro.props;
-
-const allPosts = await getCollection('posts', ({ data }) => {
-  return !data.draft;
-});
-
-const categories = [...new Set(allPosts.map(post => post.data.category))];
-
-// 計算每個分類的文章數量
-const categoryCounts = categories.reduce((acc, category) => {
-  const count = allPosts.filter(post => 
-    post.data.category === category
-  ).length;
-  
-  return {
-    ...acc,
-    [category]: count
-  };
-}, {} as Record<string, number>);
 ---
-<div class="px-2">
-  <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">Categories</h2>
-  <ul class="space-y-1">
-    {categories.map(cat => (
-      <li class="hover:bg-gray-100 dark:hover:bg-background-secondary transition-colors duration-300 px-2 py-1 rounded-md">
-        <a 
-          href={`/blog/category/${slugify(cat)}`}
-          class={`block hover:text-primary transition-colors flex justify-between items-center text-xs ${cat === currentCategory ? 'text-primary font-medium' : 'text-text-secondary'}`}
-        >
-          <span>{cat}</span>
-          <span class="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-1.5 py-0.5 rounded-full text-xs opacity-70">
-            {categoryCounts[cat]}
-          </span>
-        </a>
-      </li>
-    ))}
-  </ul>
-</div> 
+<CategoryList
+  collectionName="posts"
+  heading="Categories"
+  basePath="/blog"
+  currentCategory={currentCategory}
+/>

--- a/src/components/common/CategoryList.astro
+++ b/src/components/common/CategoryList.astro
@@ -1,0 +1,45 @@
+---
+import { getCollection } from 'astro:content';
+import { slugify } from "../../ts/utils";
+
+interface Props {
+  collectionName: string;
+  heading: string;
+  basePath: string;
+  currentCategory?: string;
+}
+
+const { collectionName, heading, basePath, currentCategory } = Astro.props as Props;
+
+const allItems = await getCollection(collectionName as any, ({ data }) => {
+  return !data.draft;
+});
+
+const categories = [...new Set(allItems.map(item => item.data.category))];
+
+const categoryCounts = categories.reduce((acc, category) => {
+  const count = allItems.filter(item => item.data.category === category).length;
+  return {
+    ...acc,
+    [category]: count
+  };
+}, {} as Record<string, number>);
+---
+<div class="px-2">
+  <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">{heading}</h2>
+  <ul class="space-y-1">
+    {categories.map(cat => (
+      <li class="hover:bg-gray-100 dark:hover:bg-background-secondary transition-colors duration-300 px-2 py-1 rounded-md">
+        <a
+          href={`${basePath}/category/${slugify(cat)}`}
+          class={`block hover:text-primary transition-colors flex justify-between items-center text-xs ${cat === currentCategory ? 'text-primary font-medium' : 'text-text-secondary'}`}
+        >
+          <span>{cat}</span>
+          <span class="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-1.5 py-0.5 rounded-full text-xs opacity-70">
+            {categoryCounts[cat]}
+          </span>
+        </a>
+      </li>
+    ))}
+  </ul>
+</div>

--- a/src/components/project/ProjectCategoryList.astro
+++ b/src/components/project/ProjectCategoryList.astro
@@ -1,47 +1,15 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import CategoryList from '../common/CategoryList.astro';
 
 interface Props {
   currentCategory?: string;
 }
 
 const { currentCategory } = Astro.props;
-
-const allProjects = await getCollection('projects', ({ data }) => {
-  return !data.draft;
-});
-
-const categories = [...new Set(allProjects.map(project => project.data.category))];
-
-// 計算每個分類的專案數量
-const categoryCounts = categories.reduce((acc, category) => {
-  const count = allProjects.filter(project =>
-    project.data.category === category
-  ).length;
-
-  return {
-    ...acc,
-    [category]: count
-  };
-}, {} as Record<string, number>);
 ---
-
-  <div class="px-2">
-  <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">Project Categories</h2>
-  <ul class="space-y-1">
-    {categories.map(cat => (
-      <li class="hover:bg-gray-100 dark:hover:bg-background-secondary transition-colors duration-300 px-2 py-1 rounded-md">
-        <a
-          href={`/project/category/${slugify(cat)}`}
-          class={`block hover:text-primary transition-colors flex justify-between items-center text-xs ${cat === currentCategory ? 'text-primary font-medium' : 'text-text-secondary'}`}
-        >
-          <span>{cat}</span>
-          <span class="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-1.5 py-0.5 rounded-full text-xs opacity-70">
-            {categoryCounts[cat]}
-          </span>
-        </a>
-      </li>
-    ))}
-  </ul>
-</div> 
+<CategoryList
+  collectionName="projects"
+  heading="Project Categories"
+  basePath="/project"
+  currentCategory={currentCategory}
+/>


### PR DESCRIPTION
## Summary
- add `CategoryList` component for shared collection category rendering
- use `CategoryList` in blog and project category wrappers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a356364c148324a4d49ae9b2d225dc