### PR TITLE
Refactor sorting logic with shared helper

### DIFF
--- a/src/components/blog/PopularPosts.astro
+++ b/src/components/blog/PopularPosts.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import { formatDate } from "../../ts/utils";
+import { formatDate, sortAndLimit } from "../../ts/utils";
 
 interface Props {
   limit?: number;
@@ -13,9 +13,7 @@ const allPosts = await getCollection('posts', ({ data }) => {
 });
 
 // 獲取熱門文章（按日期排序，取前N篇）
-const popularPosts = allPosts
-  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
-  .slice(0, limit);
+const popularPosts = sortAndLimit(allPosts, limit);
 ---
 
   <div class="px-2">

--- a/src/components/common/RelatedItems.astro
+++ b/src/components/common/RelatedItems.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
-import { formatDate, slugify } from '../../ts/utils';
+import { formatDate, slugify, sortAndLimit } from '../../ts/utils';
 
 interface Props {
   currentItem: CollectionEntry<any>;
@@ -20,17 +20,14 @@ const allItems = await getCollection(collection as any, ({ data }) => {
   return !data.draft;
 });
 
-const relatedItems = allItems
-  .filter(item =>
-    item.id !== currentItem.id &&
-    item.data.category === currentItem.data.category
-  )
-  .sort(
-    (a, b) =>
-      new Date(b.data.date ?? 0).getTime() -
-      new Date(a.data.date ?? 0).getTime()
-  )
-  .slice(0, limit);
+const relatedItems = sortAndLimit(
+  allItems.filter(
+    item =>
+      item.id !== currentItem.id &&
+      item.data.category === currentItem.data.category
+  ),
+  limit
+);
 ---
 
 {relatedItems.length > 0 && (

--- a/src/components/project/PopularProjects.astro
+++ b/src/components/project/PopularProjects.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import { slugify, formatDate } from "../../ts/utils";
+import { slugify, formatDate, sortAndLimit } from "../../ts/utils";
 
 interface Props {
   limit?: number;
@@ -13,9 +13,7 @@ const allProjects = await getCollection('projects', ({ data }) => {
 });
 
 // 獲取熱門專案（按日期排序，取前N篇）
-const popularProjects = allProjects
-  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
-  .slice(0, limit);
+const popularProjects = sortAndLimit(allProjects, limit);
 ---
 
   <div class="px-2">

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import { sortAndLimit } from "../ts/utils";
 
 import MainLayout from "./MainLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
@@ -39,11 +40,14 @@ const {
 } = post.data as PostFrontmatter;
 
 // console.log('aaa', post);
-const relatedPosts = allPosts.filter(
-  (post: CollectionEntry<'posts'>) => 
-    post.data.category.toLowerCase() === category.toLowerCase() && 
-    post.data.title !== title
-).slice(0,3);
+const relatedPosts = sortAndLimit(
+  allPosts.filter(
+    (post: CollectionEntry<'posts'>) =>
+      post.data.category.toLowerCase() === category.toLowerCase() &&
+      post.data.title !== title
+  ),
+  3
+);
 
 // 處理 cover 屬性
 const coverData = image ? { src: image.src, alt: image.alt } : undefined;

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import { sortAndLimit } from "../ts/utils";
 
 import MainLayout from "./MainLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
@@ -38,11 +39,14 @@ const {
   images,
 } = project.data as ProjectFrontmatter;
 
-const relatedProjects = allProjects.filter(
-  (project: CollectionEntry<'projects'>) => 
-    project.data.category.toLowerCase() === category.toLowerCase() && 
-    project.data.title !== title
-).slice(0,3);
+const relatedProjects = sortAndLimit(
+  allProjects.filter(
+    (project: CollectionEntry<'projects'>) =>
+      project.data.category.toLowerCase() === category.toLowerCase() &&
+      project.data.title !== title
+  ),
+  3
+);
 ---
 
 <MainLayout {title} {description} image={cover} project={project?.data}>

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,5 +1,3 @@
-import type { Project } from "../../types";
-
 export function invalidResult(): never {
   throw new Error('Invalid result')
 }
@@ -25,39 +23,15 @@ export function formatDate(date: Date) {
   })
 }
 
-export function formatProjectPost(posts: Project[], {
-  filterOutDrafts = true,
-  filterOutFuturePosts = true,
-  sortByDate = true,
-  limit = undefined as number | undefined,
-} = {}) {
-  const filteredPosts = posts.reduce((acc, post) => {
-    const { date, draft } = post.frontmatter;
+export function sortAndLimit<T extends { data: { date?: string | number } }>(
+  items: T[],
+  limit?: number
+) {
+  const sorted = [...items].sort(
+    (a, b) =>
+      new Date(b.data.date ?? 0).getTime() -
+      new Date(a.data.date ?? 0).getTime()
+  );
 
-    // filterOutDrafts if true
-    if (filterOutDrafts && draft) return acc;
-
-    // filterOutFuturePosts if true
-    if (filterOutFuturePosts && new Date(date) > new Date()) return acc;
-    // add post to acc
-    acc.push(post);
-    return acc;
-  }, [] as Project[])
-  // sort by date or randomize
-  if (sortByDate) {
-    filteredPosts.sort((a, b) => {
-      const dateA = new Date((a as Project).frontmatter.date).getTime();
-      const dateB = new Date((b as Project).frontmatter.date).getTime();
-      return dateB - dateA;
-    });
-  } else {
-    filteredPosts.sort(() => Math.random() - 0.5);
-  }
-
-  // limit if number is passed
-  if (typeof limit === "number") {
-    return filteredPosts.slice(0, limit);
-  }
-
-  return filteredPosts;
+  return typeof limit === "number" ? sorted.slice(0, limit) : sorted;
 }


### PR DESCRIPTION
## Summary
- introduce generic `sortAndLimit` helper
- refactor popular and related item queries to use shared sorting/limiting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58c6ee0788324a8eb1c91c40b1775