### PR TITLE
refactor: use RelatedItems component in layouts

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,7 +1,4 @@
 ---
-import { getCollection } from 'astro:content';
-import type { CollectionEntry } from 'astro:content';
-
 import MainLayout from "./MainLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
 
@@ -22,10 +19,6 @@ interface PostFrontmatter {
   }[];
 }
 
-const allPosts = await getCollection('posts', ({ data }: CollectionEntry<'posts'>) => {
-  return !data.draft;
-});
-
 const { post } = Astro.props;
 
 const {
@@ -37,13 +30,6 @@ const {
   image,
   images,
 } = post.data as PostFrontmatter;
-
-// console.log('aaa', post);
-const relatedPosts = allPosts.filter(
-  (post: CollectionEntry<'posts'>) => 
-    post.data.category.toLowerCase() === category.toLowerCase() && 
-    post.data.title !== title
-).slice(0,3);
 
 // 處理 cover 屬性
 const coverData = image ? { src: image.src, alt: image.alt } : undefined;

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,9 +1,7 @@
 ---
-import { getCollection } from 'astro:content';
-import type { CollectionEntry } from 'astro:content';
-
 import MainLayout from "./MainLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
+import RelatedItems from "../components/common/RelatedItems.astro";
 
 interface ProjectFrontmatter {
   draft: boolean;
@@ -22,10 +20,6 @@ interface ProjectFrontmatter {
   }[];
 }
 
-const allProjects = await getCollection('projects', ({ data }: CollectionEntry<'projects'>) => {
-  return !data.draft;
-});
-
 const { project } = Astro.props;
 
 const {
@@ -38,11 +32,6 @@ const {
   images,
 } = project.data as ProjectFrontmatter;
 
-const relatedProjects = allProjects.filter(
-  (project: CollectionEntry<'projects'>) => 
-    project.data.category.toLowerCase() === category.toLowerCase() && 
-    project.data.title !== title
-).slice(0,3);
 ---
 
 <MainLayout {title} {description} image={cover} project={project?.data}>
@@ -57,24 +46,22 @@ const relatedProjects = allProjects.filter(
       <aside class="sidebar-widget" aria-label="Project categories">
         <h2 class="text-xl font-bold mb-4">Project Categories</h2>
       </aside>
-      {
-        relatedProjects.length > 0 && (
-        <aside class="sidebar-widget" aria-label="Related projects">
-          <h2 class="text-xl font-bold mb-4">Related Projects</h2>
-        </aside>
-        )
-      }
+      <aside class="sidebar-widget" aria-label="Related projects">
+        <h2 class="text-xl font-bold mb-4">Related Projects</h2>
+        <RelatedItems currentItem={project} collection="projects" linkPrefix="/project" limit={3} />
+      </aside>
     </div>
   </div>
   {images && (
     <div class="auto-grid">
       {images.map((image) => (
-        <img 
-          src={image.src} 
-          alt={image.alt} 
+        <img
+          src={image.src}
+          alt={image.alt}
           class="w-full h-[300px] object-cover rounded-lg"
         />
       ))}
     </div>
   )}
 </MainLayout>
+


### PR DESCRIPTION
## Summary
- simplify PostLayout by removing redundant related post calculation
- switch ProjectLayout to render related items with `RelatedItems` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a58c78bc508324a1476bd9280b0893