### PR TITLE
refactor: introduce base content layout

### DIFF
--- a/src/layouts/BaseContentLayout.astro
+++ b/src/layouts/BaseContentLayout.astro
@@ -1,0 +1,35 @@
+---
+import MainLayout from "./MainLayout.astro";
+
+interface BaseContentProps {
+  title: string;
+  description: string;
+  image?: {
+    src: string;
+    alt: string;
+  };
+  images?: {
+    src: string;
+    alt: string;
+  }[];
+  post?: unknown;
+  project?: unknown;
+}
+
+const { title, description, image, images, post, project } =
+  Astro.props as BaseContentProps;
+---
+<MainLayout {title} {description} {image} {post} {project}>
+  <slot />
+  {images && (
+    <div class="auto-grid">
+      {images.map((image) => (
+        <img
+          src={image.src}
+          alt={image.alt}
+          class="w-full h-[300px] object-cover rounded-lg"
+        />
+      ))}
+    </div>
+  )}
+</MainLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -2,7 +2,7 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 
-import MainLayout from "./MainLayout.astro";
+import BaseContentLayout from "./BaseContentLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
 
 interface PostFrontmatter {
@@ -49,7 +49,7 @@ const relatedPosts = allPosts.filter(
 const coverData = image ? { src: image.src, alt: image.alt } : undefined;
 ---
 
-<MainLayout {title} {description} image={image} post={post.data}>
+<BaseContentLayout {title} {description} image={image} {images} post={post.data}>
   <PostHeader
     {title} {description} {date} {category} cover={coverData} designers={designers || []}
   />
@@ -58,15 +58,4 @@ const coverData = image ? { src: image.src, alt: image.alt } : undefined;
       <slot />
     </div>
   </div>
-  {images && (
-    <div class="auto-grid">
-      {images.map((image) => (
-        <img 
-          src={image.src} 
-          alt={image.alt} 
-          class="w-full h-[300px] object-cover rounded-lg"
-        />
-      ))}
-    </div>
-  )}
-</MainLayout>
+</BaseContentLayout>

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -2,7 +2,7 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 
-import MainLayout from "./MainLayout.astro";
+import BaseContentLayout from "./BaseContentLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
 
 interface ProjectFrontmatter {
@@ -45,7 +45,7 @@ const relatedProjects = allProjects.filter(
 ).slice(0,3);
 ---
 
-<MainLayout {title} {description} image={cover} project={project?.data}>
+<BaseContentLayout {title} {description} image={cover} {images} project={project?.data}>
   <PostHeader
     {title} {description} {date} {category} {cover} {designers}
   />
@@ -66,15 +66,4 @@ const relatedProjects = allProjects.filter(
       }
     </div>
   </div>
-  {images && (
-    <div class="auto-grid">
-      {images.map((image) => (
-        <img 
-          src={image.src} 
-          alt={image.alt} 
-          class="w-full h-[300px] object-cover rounded-lg"
-        />
-      ))}
-    </div>
-  )}
-</MainLayout>
+</BaseContentLayout>


### PR DESCRIPTION
## Summary
- add BaseContentLayout for shared title/description/image/images handling
- refactor PostLayout and ProjectLayout to use BaseContentLayout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a58c7a972c83249f5fc1ba43ea8e90