### PR TITLE
feat: extract TagList component

### DIFF
--- a/src/components/common/TagList.astro
+++ b/src/components/common/TagList.astro
@@ -1,0 +1,22 @@
+---
+import { slugify } from '../../ts/utils';
+
+interface Props {
+  tags?: string[];
+  basePath: string;
+}
+
+const { tags = [], basePath } = Astro.props as Props;
+---
+{tags.length > 0 && (
+  <div class="flex flex-wrap gap-2">
+    {tags.map((tag: string) => (
+      <a
+        href={`${basePath}/${slugify(tag)}`}
+        class="px-3 py-1 bg-background-tertiary rounded-full text-sm hover:bg-primary hover:text-white transition-colors"
+      >
+        #{tag}
+      </a>
+    ))}
+  </div>
+)}

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -3,6 +3,7 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import PostLayout from '../../layouts/PostLayout.astro';
 import CategorySection from '../../components/blog/CategorySection.astro';
 import RelatedItems from '../../components/common/RelatedItems.astro';
+import TagList from '../../components/common/TagList.astro';
 import { slugify, formatDate } from '../../ts/utils';
 
 export const prerender = true;
@@ -82,16 +83,7 @@ const { Content, headings } = await post.render();
       <!-- tag list -->
       {post.data.tags && post.data.tags.length > 0 && (
         <div class="mb-8">
-          <div class="flex flex-wrap gap-2">
-            {post.data.tags.map(tag => (
-              <a
-                href={`/blog/tag/${slugify(tag)}`}
-                class="px-3 py-1 bg-background-tertiary rounded-full text-sm hover:bg-primary hover:text-white transition-colors"
-              >
-                #{tag}
-              </a>
-            ))}
-          </div>
+          <TagList tags={post.data.tags} basePath="/blog/tag" />
         </div>
       )}
       <!-- article content -->

--- a/src/pages/project/[project].astro
+++ b/src/pages/project/[project].astro
@@ -1,8 +1,9 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
-import { slugify, formatDate } from '../../ts/utils';
+import { slugify } from '../../ts/utils';
 import MainLayout from '../../layouts/MainLayout.astro';
 import RelatedItems from '../../components/common/RelatedItems.astro';
+import TagList from '../../components/common/TagList.astro';
 import ProjectInfo from '../../components/project/ProjectInfo.astro';
 import PostHeader from '../../components/layout/PostHeader.astro';
 
@@ -70,16 +71,7 @@ const coverData = typeof data.cover === 'string' && data.cover
       {data.tags && data.tags.length > 0 && (
         <div id="tags" class="mb-8">
           <h3 class="text-2xl font-bold mb-4">Tags</h3>
-          <div class="flex flex-wrap gap-2">
-            {data.tags.map((tag: string) => (
-              <a
-                href={`/tag/${slugify(tag)}`}
-                class="px-3 py-1 bg-background-tertiary rounded-full text-sm hover:bg-primary hover:text-white transition-colors"
-              >
-                #{tag}
-              </a>
-            ))}
-          </div>
+          <TagList tags={data.tags} basePath="/tag" />
         </div>
       )}
       


### PR DESCRIPTION
## Summary
- add reusable `TagList` component
- use `TagList` in blog and project pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a58c7e53d883249b59200f8020f9b9