### PR TITLE
feat: add countByField util

### DIFF
--- a/src/components/common/CategoryList.astro
+++ b/src/components/common/CategoryList.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, countByField } from "../../ts/utils";
 
 interface Props {
   collectionName: string;
@@ -15,15 +15,8 @@ const allItems = await getCollection(collectionName as any, ({ data }) => {
   return !data.draft;
 });
 
-const categories = [...new Set(allItems.map(item => item.data.category))];
-
-const categoryCounts = categories.reduce((acc, category) => {
-  const count = allItems.filter(item => item.data.category === category).length;
-  return {
-    ...acc,
-    [category]: count
-  };
-}, {} as Record<string, number>);
+const categoryCounts = countByField(allItems, 'category');
+const categories = Object.keys(categoryCounts);
 ---
 <div class="px-2">
   <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">{heading}</h2>

--- a/src/components/common/TagClout.astro
+++ b/src/components/common/TagClout.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, countByField } from "../../ts/utils";
 
 interface Props {
   showCount?: boolean;
@@ -13,18 +13,7 @@ const allProjects = await getCollection(collectionName, ({ data }) => {
   return !data.draft;
 });
 
-const allCategories = allProjects
-  .map((project) => project.data.tags?.map(tag => tag.toLowerCase()))
-  .flat()
-  .filter((tag): tag is string => Boolean(tag));
-
-const processedCats = allCategories.reduce((acc, cat) => {
-  const value = acc[cat] || 0;
-  return {
-    ...acc,
-    [cat]: value + 1,
-  };
-}, {} as Record<string, number>);
+const processedCats = countByField(allProjects, 'tags');
 ---
 
 <ul class="categories">

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -61,3 +61,23 @@ export function formatProjectPost(posts: Project[], {
 
   return filteredPosts;
 }
+
+export function countByField<T extends { data?: Record<string, any> }>(
+  items: T[],
+  field: string
+): Record<string, number> {
+  return items.reduce((acc, item) => {
+    const value = item?.data?.[field];
+    if (Array.isArray(value)) {
+      value.forEach((val) => {
+        if (!val) return;
+        const key = typeof val === "string" ? val.toLowerCase() : String(val);
+        acc[key] = (acc[key] || 0) + 1;
+      });
+    } else if (value) {
+      const key = String(value);
+      acc[key] = (acc[key] || 0) + 1;
+    }
+    return acc;
+  }, {} as Record<string, number>);
+}


### PR DESCRIPTION
## Summary
- add `countByField` utility to tally values for a given field
- refactor `CategoryList` and `TagClout` components to reuse `countByField`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a58ca90be483249cdf5998e60a0843