### PR TITLE
feat: centralize published collection retrieval

### DIFF
--- a/src/components/blog/PopularPosts.astro
+++ b/src/components/blog/PopularPosts.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { formatDate } from "../../ts/utils";
+import { formatDate, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   limit?: number;
@@ -8,9 +7,7 @@ interface Props {
 
 const { limit = 5 } = Astro.props;
 
-const allPosts = await getCollection('posts', ({ data }) => {
-  return !data.draft;
-});
+const allPosts = await getPublishedCollection('posts');
 
 // 獲取熱門文章（按日期排序，取前N篇）
 const popularPosts = allPosts

--- a/src/components/common/CategoryList.astro
+++ b/src/components/common/CategoryList.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   collectionName: string;
@@ -11,9 +10,7 @@ interface Props {
 
 const { collectionName, heading, basePath, currentCategory } = Astro.props as Props;
 
-const allItems = await getCollection(collectionName as any, ({ data }) => {
-  return !data.draft;
-});
+const allItems = await getPublishedCollection(collectionName as any);
 
 const categories = [...new Set(allItems.map(item => item.data.category))];
 

--- a/src/components/common/RelatedItems.astro
+++ b/src/components/common/RelatedItems.astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
-import { formatDate, slugify } from '../../ts/utils';
+import type { CollectionEntry } from 'astro:content';
+import { formatDate, slugify, getPublishedCollection } from '../../ts/utils';
 
 interface Props {
   currentItem: CollectionEntry<any>;
@@ -16,9 +16,7 @@ const {
   limit = 3,
 } = Astro.props as Props;
 
-const allItems = await getCollection(collection as any, ({ data }) => {
-  return !data.draft;
-});
+const allItems = await getPublishedCollection(collection as any);
 
 const relatedItems = allItems
   .filter(item =>

--- a/src/components/common/TagClout.astro
+++ b/src/components/common/TagClout.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   showCount?: boolean;
@@ -9,9 +8,7 @@ interface Props {
 
 const { showCount, collectionName = 'projects' } = Astro.props as Props;
 
-const allProjects = await getCollection(collectionName, ({ data }) => {
-  return !data.draft;
-});
+const allProjects = await getPublishedCollection(collectionName);
 
 const allCategories = allProjects
   .map((project) => project.data.tags?.map(tag => tag.toLowerCase()))

--- a/src/components/project/PopularProjects.astro
+++ b/src/components/project/PopularProjects.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify, formatDate } from "../../ts/utils";
+import { slugify, formatDate, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   limit?: number;
@@ -8,9 +7,7 @@ interface Props {
 
 const { limit = 5 } = Astro.props;
 
-const allProjects = await getCollection('projects', ({ data }) => {
-  return !data.draft;
-});
+const allProjects = await getPublishedCollection('projects');
 
 // 獲取熱門專案（按日期排序，取前N篇）
 const popularProjects = allProjects

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import { getPublishedCollection } from '../ts/utils';
 
 import MainLayout from "./MainLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
@@ -22,9 +22,7 @@ interface PostFrontmatter {
   }[];
 }
 
-const allPosts = await getCollection('posts', ({ data }: CollectionEntry<'posts'>) => {
-  return !data.draft;
-});
+const allPosts = await getPublishedCollection('posts');
 
 const { post } = Astro.props;
 

--- a/src/layouts/ProjectLayout.astro
+++ b/src/layouts/ProjectLayout.astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import { getPublishedCollection } from '../ts/utils';
 
 import MainLayout from "./MainLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
@@ -22,9 +22,7 @@ interface ProjectFrontmatter {
   }[];
 }
 
-const allProjects = await getCollection('projects', ({ data }: CollectionEntry<'projects'>) => {
-  return !data.draft;
-});
+const allProjects = await getPublishedCollection('projects');
 
 const { project } = Astro.props;
 

--- a/src/pages/_templates/CategoryPage.astro
+++ b/src/pages/_templates/CategoryPage.astro
@@ -1,13 +1,11 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import MainLayout from '../../layouts/MainLayout.astro';
-import { slugify } from '../../ts/utils';
+import { slugify, getPublishedCollection } from '../../ts/utils';
 
 export function createGetStaticPaths(collection: string) {
   return async function getStaticPaths() {
-    const allItems = await getCollection(collection, ({ data }) => {
-      return !data.draft;
-    });
+    const allItems = await getPublishedCollection(collection);
 
     const uniqueCategories = [...new Set(allItems.map(item => item.data.category))];
 

--- a/src/pages/_templates/PaginatedList.astro
+++ b/src/pages/_templates/PaginatedList.astro
@@ -1,11 +1,12 @@
 ---
 import MainLayout from '../../layouts/MainLayout.astro';
 import Pagination from '../../components/common/Pagination.astro';
-import { getCollection, type CollectionEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import { getPublishedCollection } from '../../ts/utils';
 
 export function createGetStaticPaths(collectionName: string, pageSize = 6) {
   return async function getStaticPaths({ paginate }: { paginate: any }) {
-    const allItems = await getCollection(collectionName, ({ data }) => !data.draft);
+    const allItems = await getPublishedCollection(collectionName);
     return paginate(allItems, { pageSize });
   };
 }

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,17 +1,15 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import MainLayout from '../../../layouts/MainLayout.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import CategorySection from '../../../components/blog/CategorySection.astro';
 import PopularPosts from '../../../components/blog/PopularPosts.astro';
-import { slugify } from '../../../ts/utils';
+import { slugify, getPublishedCollection } from '../../../ts/utils';
 
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('posts', ({ data }) => {
-    return !data.draft;
-  });
+  const allPosts = await getPublishedCollection('posts');
 
   const allTags = allPosts
     .flatMap((post) => (post.data.tags || []) as string[])

--- a/src/pages/project/[project].astro
+++ b/src/pages/project/[project].astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
-import { slugify, formatDate } from '../../ts/utils';
+import type { CollectionEntry } from 'astro:content';
+import { slugify, formatDate, getPublishedCollection } from '../../ts/utils';
 import MainLayout from '../../layouts/MainLayout.astro';
 import RelatedItems from '../../components/common/RelatedItems.astro';
 import ProjectInfo from '../../components/project/ProjectInfo.astro';
@@ -9,9 +9,7 @@ import PostHeader from '../../components/layout/PostHeader.astro';
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const allProjects = await getCollection('projects', ({ data }) => {
-    return !data.draft;
-  });
+  const allProjects = await getPublishedCollection('projects');
   
   return allProjects.map((project) => ({
     params: { project: project.id || slugify(project.data.title) },

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,3 +1,4 @@
+import { getCollection } from 'astro:content';
 import type { Project } from "../../types";
 
 export function invalidResult(): never {
@@ -23,6 +24,10 @@ export function formatDate(date: Date) {
   return new Date(date).toLocaleDateString('en-US', {
     timeZone: "UTC",
   })
+}
+
+export async function getPublishedCollection(collectionName: string) {
+  return await getCollection(collectionName as any, ({ data }) => !data.draft);
 }
 
 export function formatProjectPost(posts: Project[], {


### PR DESCRIPTION
## Summary
- add reusable `getPublishedCollection` to gather non-draft entries
- refactor components and templates to use the new helper instead of repeating the draft filter

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58cb1e39c8324986de3cce28c77c6