### PR TITLE
refactor popular lists into reusable component

### DIFF
--- a/src/components/blog/PopularPosts.astro
+++ b/src/components/blog/PopularPosts.astro
@@ -1,40 +1,15 @@
 ---
-import { getCollection } from 'astro:content';
-import { formatDate } from "../../ts/utils";
+import PopularItems from '../common/PopularItems.astro';
 
 interface Props {
   limit?: number;
 }
 
-const { limit = 5 } = Astro.props;
-
-const allPosts = await getCollection('posts', ({ data }) => {
-  return !data.draft;
-});
-
-// 獲取熱門文章（按日期排序，取前N篇）
-const popularPosts = allPosts
-  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
-  .slice(0, limit);
+const { limit } = Astro.props;
 ---
-
-  <div class="px-2">
-  <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">Popular Posts</h2>
-  <ul class="space-y-1">
-    {popularPosts.map(post => (
-      <li class="hover:bg-gray-100 dark:hover:bg-background-secondary transition-colors duration-300 px-2 py-1 rounded-md">
-        <a 
-          href={`/blog/${post.id}`}
-          class="block hover:text-primary transition-colors"
-        >
-          <h3 class="font-normal text-xs line-clamp-2 text-text-secondary">
-            {post.data.title}
-          </h3>
-          <span class="text-xs text-text-muted mt-1 block opacity-70">
-            {formatDate(new Date(post.data.date))}
-          </span>
-        </a>
-      </li>
-    ))}
-  </ul>
-</div> 
+<PopularItems
+  collectionName="posts"
+  title="Popular Posts"
+  limit={limit}
+  getHref={(post) => `/blog/${post.id}`}
+/>

--- a/src/components/common/PopularItems.astro
+++ b/src/components/common/PopularItems.astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from 'astro:content';
+import { formatDate } from '../../ts/utils';
+
+interface Props {
+  collectionName: string;
+  limit?: number;
+  getHref: (item: any) => string;
+  title: string;
+}
+
+const { collectionName, limit = 5, getHref, title } = Astro.props;
+
+const allItems = await getCollection(collectionName as any, ({ data }) => {
+  return !data.draft;
+});
+
+const popularItems = allItems
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+  .slice(0, limit);
+---
+<div class="px-2">
+  <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">{title}</h2>
+  <ul class="space-y-1">
+    {popularItems.map(item => (
+      <li class="hover:bg-gray-100 dark:hover:bg-background-secondary transition-colors duration-300 px-2 py-1 rounded-md">
+        <a
+          href={getHref(item)}
+          class="block hover:text-primary transition-colors"
+        >
+          <h3 class="font-normal text-xs line-clamp-2 text-text-secondary">
+            {item.data.title}
+          </h3>
+          <span class="text-xs text-text-muted mt-1 block opacity-70">
+            {formatDate(new Date(item.data.date))}
+          </span>
+        </a>
+      </li>
+    ))}
+  </ul>
+</div>

--- a/src/components/project/PopularProjects.astro
+++ b/src/components/project/PopularProjects.astro
@@ -1,40 +1,16 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify, formatDate } from "../../ts/utils";
+import PopularItems from '../common/PopularItems.astro';
+import { slugify } from '../../ts/utils';
 
 interface Props {
   limit?: number;
 }
 
-const { limit = 5 } = Astro.props;
-
-const allProjects = await getCollection('projects', ({ data }) => {
-  return !data.draft;
-});
-
-// 獲取熱門專案（按日期排序，取前N篇）
-const popularProjects = allProjects
-  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
-  .slice(0, limit);
+const { limit } = Astro.props;
 ---
-
-  <div class="px-2">
-  <h2 class="text-lg font-medium mb-3 pl-2 text-text-muted">Popular Projects</h2>
-  <ul class="space-y-1">
-    {popularProjects.map(project => (
-      <li class="hover:bg-gray-100 dark:hover:bg-background-secondary transition-colors duration-300 px-2 py-1 rounded-md">
-        <a 
-          href={`/project/${project.id || slugify(project.data.title)}`}
-          class="block hover:text-primary transition-colors"
-        >
-          <h3 class="font-normal text-xs line-clamp-2 text-text-secondary">
-            {project.data.title}
-          </h3>
-          <span class="text-xs text-text-muted mt-1 block opacity-70">
-            {formatDate(new Date(project.data.date))}
-          </span>
-        </a>
-      </li>
-    ))}
-  </ul>
-</div> 
+<PopularItems
+  collectionName="projects"
+  title="Popular Projects"
+  limit={limit}
+  getHref={(project) => `/project/${project.id || slugify(project.data.title)}`}
+/>


### PR DESCRIPTION
## Summary
- add generic `PopularItems` component for sorting and rendering popular content
- refactor `PopularPosts` and `PopularProjects` to use shared component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a58cb6edc883248a8a0eb9271607a1