### PR TITLE
chore: remove unused Link import

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -1,5 +1,4 @@
 ---
-import Link from "../common/Link.astro";
 import { slugify, formatDate } from "../../ts/utils"
 
 const { post } = Astro.props;


### PR DESCRIPTION
## Summary
- remove unused Link import from PostCard component

## Testing
- `npx tsc --noEmit`
- `npx eslint src/components/blog/PostCard.astro` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: ENETUNREACH when fetching web fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68add6e007d88324b957a8e1ee30dce4