### PR TITLE
refactor: add collection page factory

### DIFF
--- a/src/pages/_templates/CollectionPage.astro
+++ b/src/pages/_templates/CollectionPage.astro
@@ -1,0 +1,44 @@
+---
+import PaginatedList, { createGetStaticPaths } from './PaginatedList.astro';
+
+interface SidebarComponent {
+  component: any;
+  props?: Record<string, any>;
+}
+
+interface CreateCollectionConfig {
+  collectionName: string;
+  cardComponent: any;
+  sidebarComponents: SidebarComponent[];
+  title?: string;
+  pageSize?: number;
+}
+
+export function createCollectionPage({
+  collectionName,
+  cardComponent,
+  sidebarComponents,
+  title,
+  pageSize = 6
+}: CreateCollectionConfig) {
+  return {
+    getStaticPaths: createGetStaticPaths(collectionName, pageSize),
+    props: { collectionName, cardComponent, sidebarComponents, title }
+  };
+}
+
+const {
+  collectionName,
+  cardComponent,
+  sidebarComponents,
+  page,
+  title
+} = Astro.props;
+---
+<PaginatedList
+  collectionName={collectionName}
+  cardComponent={cardComponent}
+  sidebarComponents={sidebarComponents}
+  page={page}
+  title={title}
+/>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,22 +1,22 @@
 ---
-import PaginatedList, { createGetStaticPaths } from '../_templates/PaginatedList.astro';
+import CollectionPage, { createCollectionPage } from '../_templates/CollectionPage.astro';
 import PostCard from '../../components/blog/PostCard.astro';
 import CategoryList from '../../components/common/CategoryList.astro';
 import PopularPosts from '../../components/blog/PopularPosts.astro';
 
 export const prerender = true;
-export const getStaticPaths = createGetStaticPaths('posts', 6);
 
-const sidebarComponents = [
-  { component: CategoryList, props: { collectionName: 'posts', heading: 'Categories', basePath: '/blog' } },
-  { component: PopularPosts }
-];
+const { getStaticPaths, props } = createCollectionPage({
+  collectionName: 'posts',
+  cardComponent: PostCard,
+  sidebarComponents: [
+    { component: CategoryList, props: { collectionName: 'posts', heading: 'Categories', basePath: '/blog' } },
+    { component: PopularPosts }
+  ]
+});
+
+export { getStaticPaths };
+
 const { page } = Astro.props;
 ---
-
-<PaginatedList
-  collectionName="posts"
-  cardComponent={PostCard}
-  sidebarComponents={sidebarComponents}
-  page={page}
-/>
+<CollectionPage {...props} page={page} />

--- a/src/pages/project/[...page].astro
+++ b/src/pages/project/[...page].astro
@@ -1,23 +1,23 @@
 ---
-import PaginatedList, { createGetStaticPaths } from '../_templates/PaginatedList.astro';
+import CollectionPage, { createCollectionPage } from '../_templates/CollectionPage.astro';
 import ProjectCard from '../../components/project/ProjectCard.astro';
 import CategoryList from '../../components/common/CategoryList.astro';
 import PopularProjects from '../../components/project/PopularProjects.astro';
 
 export const prerender = true;
-export const getStaticPaths = createGetStaticPaths('projects', 6);
 
-const sidebarComponents = [
-  { component: CategoryList, props: { collectionName: 'projects', heading: 'Project Categories', basePath: '/project' } },
-  { component: PopularProjects }
-];
+const { getStaticPaths, props } = createCollectionPage({
+  collectionName: 'projects',
+  cardComponent: ProjectCard,
+  sidebarComponents: [
+    { component: CategoryList, props: { collectionName: 'projects', heading: 'Project Categories', basePath: '/project' } },
+    { component: PopularProjects }
+  ],
+  title: '案例作品'
+});
+
+export { getStaticPaths };
+
 const { page } = Astro.props;
 ---
-
-<PaginatedList
-  collectionName="projects"
-  cardComponent={ProjectCard}
-  sidebarComponents={sidebarComponents}
-  page={page}
-  title="案例作品"
-/>
+<CollectionPage {...props} page={page} />


### PR DESCRIPTION
## Summary
- add CollectionPage template with `createCollectionPage` factory for paginated collections
- refactor blog and project dynamic routes to use shared collection page config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: The collection "posts" does not exist or is empty; GetStaticPathsRequired)*


------
https://chatgpt.com/codex/tasks/task_e_68b076be42ac832494dcaa8871f6f5c8