### PR TITLE
refactor: centralize published content retrieval

### DIFF
--- a/src/components/common/CategoryList.astro
+++ b/src/components/common/CategoryList.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   collectionName: string;
@@ -11,9 +10,7 @@ interface Props {
 
 const { collectionName, heading, basePath, currentCategory } = Astro.props as Props;
 
-const allItems = await getCollection(collectionName as any, ({ data }) => {
-  return !data.draft;
-});
+const allItems = await getPublishedCollection(collectionName as any);
 
 const categories = [...new Set(allItems.map(item => item.data.category))];
 

--- a/src/components/common/PopularItems.astro
+++ b/src/components/common/PopularItems.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify, formatDate, sortAndLimit } from "../../ts/utils";
+import { slugify, formatDate, sortAndLimit, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   collectionName: string;
@@ -10,9 +9,7 @@ interface Props {
 
 const { collectionName, linkPrefix, limit = 5 } = Astro.props;
 
-const allItems = await getCollection(collectionName, ({ data }) => {
-  return !data.draft;
-});
+const allItems = await getPublishedCollection(collectionName);
 
 // 獲取熱門項目（按日期排序，取前N篇）
 const popularItems = sortAndLimit(allItems, limit);

--- a/src/components/common/RelatedItems.astro
+++ b/src/components/common/RelatedItems.astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
-import { formatDate, slugify, sortAndLimit } from '../../ts/utils';
+import { type CollectionEntry } from 'astro:content';
+import { formatDate, slugify, sortAndLimit, getPublishedCollection } from '../../ts/utils';
 
 interface Props {
   currentItem: CollectionEntry<any>;
@@ -16,9 +16,7 @@ const {
   limit = 3,
 } = Astro.props as Props;
 
-const allItems = await getCollection(collection as any, ({ data }) => {
-  return !data.draft;
-});
+const allItems = await getPublishedCollection(collection as any);
 
 const relatedItems = sortAndLimit(
   allItems.filter(

--- a/src/components/common/TagClout.astro
+++ b/src/components/common/TagClout.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { slugify } from "../../ts/utils";
+import { slugify, getPublishedCollection } from "../../ts/utils";
 
 interface Props {
   showCount?: boolean;
@@ -9,9 +8,7 @@ interface Props {
 
 const { showCount, collectionName = 'projects' } = Astro.props as Props;
 
-const allProjects = await getCollection(collectionName, ({ data }) => {
-  return !data.draft;
-});
+const allProjects = await getPublishedCollection(collectionName);
 
 const allCategories = allProjects
   .map((project) => project.data.tags?.map(tag => tag.toLowerCase()))

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,7 +1,6 @@
 ---
-import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
-import { sortAndLimit } from "../ts/utils";
+import { sortAndLimit, getPublishedCollection } from "../ts/utils";
 
 import BaseContentLayout from "./BaseContentLayout.astro";
 import PostHeader from "../components/layout/PostHeader.astro";
@@ -23,9 +22,7 @@ interface PostFrontmatter {
   }[];
 }
 
-const allPosts = await getCollection('posts', ({ data }: CollectionEntry<'posts'>) => {
-  return !data.draft;
-});
+const allPosts = await getPublishedCollection('posts');
 
 const { post } = Astro.props;
 

--- a/src/pages/_templates/CategoryPage.astro
+++ b/src/pages/_templates/CategoryPage.astro
@@ -1,14 +1,12 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { type CollectionEntry } from 'astro:content';
 import MainLayout from '../../layouts/MainLayout.astro';
 import CategoryList from '../../components/common/CategoryList.astro';
-import { slugify } from '../../ts/utils';
+import { slugify, getPublishedCollection } from '../../ts/utils';
 
 export function createGetStaticPaths(collection: string) {
   return async function getStaticPaths() {
-    const allItems = await getCollection(collection, ({ data }) => {
-      return !data.draft;
-    });
+    const allItems = await getPublishedCollection(collection);
 
     const uniqueCategories = [...new Set(allItems.map(item => item.data.category))];
 

--- a/src/pages/_templates/PaginatedList.astro
+++ b/src/pages/_templates/PaginatedList.astro
@@ -1,11 +1,12 @@
 ---
 import MainLayout from '../../layouts/MainLayout.astro';
 import Pagination from '../../components/common/Pagination.astro';
-import { getCollection, type CollectionEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import { getPublishedCollection } from '../../ts/utils';
 
 export function createGetStaticPaths(collectionName: string, pageSize = 6) {
   return async function getStaticPaths({ paginate }: { paginate: any }) {
-    const allItems = await getCollection(collectionName, ({ data }) => !data.draft);
+    const allItems = await getPublishedCollection(collectionName);
     return paginate(allItems, { pageSize });
   };
 }

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -1,16 +1,16 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { type CollectionEntry } from 'astro:content';
 import PostLayout from '../../layouts/PostLayout.astro';
 import CategoryList from '../../components/common/CategoryList.astro';
 import RelatedItems from '../../components/common/RelatedItems.astro';
 import TagList from '../../components/common/TagList.astro';
 import BuyMeACoffee from '../../components/common/BuyMeACoffee.astro';
-import { slugify, formatDate } from '../../ts/utils';
+import { slugify, formatDate, getPublishedCollection } from '../../ts/utils';
 
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('posts');
+  const allPosts = await getPublishedCollection('posts');
   return allPosts.map((post) => ({
     params: { post: post.id },
     props: { post }

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,17 +1,15 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { type CollectionEntry } from 'astro:content';
 import MainLayout from '../../../layouts/MainLayout.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import CategoryList from '../../../components/common/CategoryList.astro';
 import PopularItems from '../../../components/common/PopularItems.astro';
-import { slugify } from '../../../ts/utils';
+import { slugify, getPublishedCollection } from '../../../ts/utils';
 
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const allPosts = await getCollection('posts', ({ data }) => {
-    return !data.draft;
-  });
+  const allPosts = await getPublishedCollection('posts');
 
   const allTags = allPosts
     .flatMap((post) => (post.data.tags || []) as string[])

--- a/src/pages/project/[project].astro
+++ b/src/pages/project/[project].astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection, type CollectionEntry } from 'astro:content';
-import { slugify } from '../../ts/utils';
+import { type CollectionEntry } from 'astro:content';
+import { slugify, getPublishedCollection } from '../../ts/utils';
 import MainLayout from '../../layouts/MainLayout.astro';
 import RelatedItems from '../../components/common/RelatedItems.astro';
 import TagList from '../../components/common/TagList.astro';
@@ -11,9 +11,7 @@ import BuyMeACoffee from '../../components/common/BuyMeACoffee.astro';
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const allProjects = await getCollection('projects', ({ data }) => {
-    return !data.draft;
-  });
+  const allProjects = await getPublishedCollection('projects');
   
   return allProjects.map((project) => ({
     params: { project: project.id || slugify(project.data.title) },

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -1,3 +1,5 @@
+import { getCollection } from 'astro:content';
+
 export function invalidResult(): never {
   throw new Error('Invalid result')
 }
@@ -34,4 +36,8 @@ export function sortAndLimit<T extends { data: { date?: string | number } }>(
   );
 
   return typeof limit === "number" ? sorted.slice(0, limit) : sorted;
+}
+
+export function getPublishedCollection(collection: string) {
+  return getCollection(collection as any, ({ data }) => !data.draft);
 }


### PR DESCRIPTION
## Summary
- add `getPublishedCollection` utility wrapping `getCollection` with draft filtering
- refactor components and pages to use `getPublishedCollection` and drop inline draft filters

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails to fetch fonts but build completed)

------
https://chatgpt.com/codex/tasks/task_e_68b8558213c48324803a4d8d65fc7279