### PR TITLE
chore: improve svg accessibility

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -54,7 +54,15 @@ const imageAlt = image?.alt || title || "文章圖片";
       class="inline-flex items-center text-primary group-hover:underline"
     >
       閱讀更多
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-4 w-4 ml-1 transition-transform group-hover:translate-x-1"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+        focusable="false"
+      >
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
       </svg>
     </a>

--- a/src/components/common/ThemeToggle.astro
+++ b/src/components/common/ThemeToggle.astro
@@ -8,14 +8,28 @@ const { class: className = "" } = Astro.props;
   aria-label="切換深色模式"
   class={`theme-toggle ${className}`}
 >
-  <svg id="sun-icon" class="w-5 h-5 block dark:hidden" fill="currentColor" viewBox="0 0 20 20">
+  <svg
+    id="sun-icon"
+    class="w-5 h-5 block dark:hidden"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    focusable="false"
+  >
     <path
       fill-rule="evenodd"
       d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
       clip-rule="evenodd"
     />
   </svg>
-  <svg id="moon-icon" class="w-5 h-5 hidden dark:block" fill="currentColor" viewBox="0 0 20 20">
+  <svg
+    id="moon-icon"
+    class="w-5 h-5 hidden dark:block"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    focusable="false"
+  >
     <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
   </svg>
 </button>

--- a/src/components/project/ProjectCard.astro
+++ b/src/components/project/ProjectCard.astro
@@ -51,7 +51,15 @@ const projectId = project.id || slugify(title);
       class="inline-flex items-center text-primary group-hover:underline"
     >
       查看專案
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-4 w-4 ml-1 transition-transform group-hover:translate-x-1"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+        focusable="false"
+      >
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
       </svg>
     </a>


### PR DESCRIPTION
## Summary
- hide decorative SVG icons with `aria-hidden` and `focusable="false"` in theme toggle and card links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9ae74e7548324b3815e3e74185a4a