### PR TITLE
feat: enable text selection and default browser interactions

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -18,7 +18,7 @@ const {
 } = Astro.props;
 ---
 <!doctype html>
-<html lang="en" class="w-full h-full select-none">
+<html lang="zh-tw" class="w-full h-full">
 	<head>
 		<script is:inline>
 			// Process the theme setting before page conversion
@@ -46,30 +46,16 @@ const {
 
 <script>
 	// Process the theme setting before page conversion
-	document.addEventListener('astro:before-swap', (event) => {
-		const currentTheme = localStorage.getItem('theme') || 
-						(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-		
-		if (currentTheme === 'dark') {
-			event.newDocument.documentElement.classList.add('dark');
-		} else {
-			event.newDocument.documentElement.classList.remove('dark');
-		}
-	});
+        document.addEventListener('astro:before-swap', (event) => {
+                const currentTheme =
+                        localStorage.getItem('theme') ||
+                        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
-	function disableRightClick(e: MouseEvent) {
-		e.preventDefault();
-		return false;
-	}
-
-	function disableSelection(e: Event) {
-		e.preventDefault();
-		return false;
-	}
-
-	document.addEventListener('contextmenu', disableRightClick);
-	document.addEventListener('selectstart', disableSelection);
-	document.addEventListener('copy', disableSelection);
-	document.addEventListener('dragstart', disableSelection);
+                if (currentTheme === 'dark') {
+                        event.newDocument.documentElement.classList.add('dark');
+                } else {
+                        event.newDocument.documentElement.classList.remove('dark');
+                }
+        });
 </script>
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -26,7 +26,7 @@
 
 /* 全局樣式 */
 html {
-  @apply w-full h-full select-none;
+  @apply w-full h-full;
 }
 
 body {


### PR DESCRIPTION
## Summary
- set site language to zh-tw and remove `select-none` from `<html>`
- drop event listeners that blocked right click, selection, copy, and drag
- allow selecting text by removing `select-none` from global html styles

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68badaff44c48324a92acc219c4b80cf