### PR TITLE
feat: add skip link to main content

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -35,13 +35,14 @@ const {
 		<MainHead {title} {description} {image} {robots} {project}/>
 		<ClientRouter />
 	</head>
-	<body class="flex flex-col min-h-screen w-full m-0 bg-background text-text transition-colors duration-300">
-		<NavBar transition:persist />
-		<main class="flex-grow">
-			<slot />
-		</main>
-		<Footer class="mt-auto" transition:persist />
-	</body>
+        <body class="flex flex-col min-h-screen w-full m-0 bg-background text-text transition-colors duration-300">
+                <a href="#main-content" class="sr-only focus:not-sr-only">跳到主要內容</a>
+                <NavBar transition:persist />
+                <main id="main-content" class="flex-grow">
+                        <slot />
+                </main>
+                <Footer class="mt-auto" transition:persist />
+        </body>
 </html>
 
 <script>


### PR DESCRIPTION
## Summary
- add hidden yet focusable skip-to-content link
- mark main element with `id="main-content"`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda4c65dec83249b7a8c360a97d139