### PR TITLE
Add rel attributes to pagination links

### DIFF
--- a/src/components/common/Link.astro
+++ b/src/components/common/Link.astro
@@ -12,6 +12,7 @@ interface Props {
   isFilled?: boolean;
   borderVisible?: boolean;
   classes?: string;
+  rel?: string;
 }
 
 const {

--- a/src/components/common/Pagination.astro
+++ b/src/components/common/Pagination.astro
@@ -13,6 +13,7 @@ const { prevUrl, nextUrl } = Astro.props;
         style="primary"
         borderVisible
         isFilled
+        rel="prev"
       />
     )
   }
@@ -24,6 +25,7 @@ const { prevUrl, nextUrl } = Astro.props;
         style="primary"
         borderVisible
         isFilled
+        rel="next"
       />
     )
   }


### PR DESCRIPTION
## Summary
- include `rel="prev"` and `rel="next"` in pagination
- allow `Link` component to forward `rel` attribute

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c049c3881c8324a49127cb8179906d