### PR TITLE
Add button type attribute to theme toggle

### DIFF
--- a/src/components/common/ThemeToggle.astro
+++ b/src/components/common/ThemeToggle.astro
@@ -5,6 +5,7 @@ const { class: className = "" } = Astro.props;
 
 <button
   id="theme-toggle"
+  type="button"
   aria-label="切換深色模式"
   class={`theme-toggle ${className}`}
 >


### PR DESCRIPTION
## Summary
- add an explicit type attribute to the theme toggle button to prevent unintended form submissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc24fc1fec8324ba1ae609de156435