### PR TITLE
Add aria-current to active nav link

### DIFF
--- a/src/components/layout/NavBar.astro
+++ b/src/components/layout/NavBar.astro
@@ -37,6 +37,7 @@ const activeTabIndex = navData.findIndex(
                 index === activeTabIndex ? 'active text-primary font-bold' : ''
               }`}
               data-index={index}
+              aria-current={index === activeTabIndex ? 'page' : undefined}
             >
               {item.name}
             </a>


### PR DESCRIPTION
## Summary
- add aria-current="page" to the currently active nav item in the navbar for better accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6f0fb9908324b93e85dab57ce8f6