### PR TITLE
Fix localized path helpers and navbar language switching

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,6 +20,17 @@ export default defineConfig({
   output: 'static',
   site: url,
   base,
+  i18n: {
+    defaultLocale: 'zh-tw',
+    locales: ['zh-tw', 'en'],
+    fallback: {
+      en: 'zh-tw',
+    },
+    routing: {
+      prefixDefaultLocale: true,
+      fallbackType: 'rewrite',
+    },
+  },
   integrations: [
     icon(),
     UnoCSS({

--- a/src/components/layout/NavBar.astro
+++ b/src/components/layout/NavBar.astro
@@ -1,14 +1,46 @@
 ---
 import ThemeToggle from "../common/ThemeToggle.astro"
 import navData from '../../data/navdata';
+import {
+  getLocaleFromPath,
+  getPathWithoutLocale,
+  localizePath,
+  localizeUrl,
+  locales,
+  type Locale,
+} from '../../i18n/utils';
 
-// 獲取當前路徑，用於確定活動頁籤
-const currentPath = Astro.url.pathname;
+const currentLocale = getLocaleFromPath(Astro);
+const currentPath = getPathWithoutLocale(Astro.url.pathname);
 
-// 確定活動頁籤索引
-const activeTabIndex = navData.findIndex(
-  (item) => currentPath === item.path || currentPath.startsWith(`${item.path}/`)
-);
+const localeLabels: Record<Locale, string> = {
+  'zh-tw': '繁體中文',
+  en: 'English',
+};
+
+const navItems = navData.map((item) => {
+  const normalizedPath = getPathWithoutLocale(item.path);
+  const href = localizePath(item.path, currentLocale);
+  const isActive =
+    currentPath === normalizedPath || currentPath.startsWith(`${normalizedPath}/`);
+
+  return {
+    ...item,
+    href,
+    isActive,
+  };
+});
+
+const languageLinks = locales.map((locale) => {
+  const url = localizeUrl(Astro, locale);
+
+  return {
+    locale,
+    label: localeLabels[locale],
+    href: `${url.pathname}${url.search}${url.hash}`,
+    isActive: locale === currentLocale,
+  };
+});
 ---
 
 <nav 
@@ -33,15 +65,15 @@ const activeTabIndex = navData.findIndex(
     <!-- Center: Navigation Links -->
     <div class="flex justify-center">
       <ul class="flex items-center gap-4 py-2 relative nav-container">
-        {navData.map((item, index) => (
+        {navItems.map((item, index) => (
           <li>
             <a
-              href={import.meta.env.BASE_URL + item.path.replace(/^\//, '')}
+              href={item.href}
               class={`nav-item block px-3 py-1 relative z-10 text-gray-800 dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors ${
-                index === activeTabIndex ? 'active text-primary font-bold' : ''
+                item.isActive ? 'active text-primary font-bold' : ''
               }`}
               data-index={index}
-              aria-current={index === activeTabIndex ? 'page' : undefined}
+              aria-current={item.isActive ? 'page' : undefined}
             >
               {item.name}
             </a>
@@ -56,10 +88,31 @@ const activeTabIndex = navData.findIndex(
         ></li>
       </ul>
     </div>
-    
+
     <!-- Right: Theme Toggle -->
     <div class="flex justify-end">
-      <ThemeToggle />
+      <div class="flex items-center gap-3">
+        <nav
+          class="flex items-center gap-2 text-sm language-switcher"
+          aria-label="Language selector"
+        >
+          {languageLinks.map((link) => (
+            <a
+              href={link.href}
+              lang={link.locale}
+              data-locale={link.locale}
+              class={`rounded px-2 py-1 transition-colors ${
+                link.isActive
+                  ? 'font-semibold text-primary bg-primary/10 dark:bg-primary/20'
+                  : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+              }`}
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+        <ThemeToggle />
+      </div>
     </div>
   </div>
 </nav>

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,0 +1,144 @@
+import type { AstroGlobal } from 'astro';
+
+const RAW_LOCALES = ['zh-tw', 'en'] as const;
+
+export type Locale = typeof RAW_LOCALES[number];
+
+export const locales: readonly Locale[] = RAW_LOCALES;
+
+export const defaultLocale: Locale = 'zh-tw';
+
+function normalizeBase(base: string | undefined) {
+  if (!base || base === '/' || base === './') {
+    return '';
+  }
+
+  let normalized = base;
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+
+  if (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}
+
+function isLocale(value: string | undefined | null): value is Locale {
+  return !!value && locales.includes(value.toLowerCase() as Locale);
+}
+
+function toPathname(target: string | URL | AstroGlobal) {
+  if (target instanceof URL) {
+    return target.pathname;
+  }
+
+  if (typeof target === 'object' && 'url' in target) {
+    return (target as AstroGlobal).url.pathname;
+  }
+
+  if (typeof target === 'string') {
+    try {
+      if (target.startsWith('http://') || target.startsWith('https://')) {
+        return new URL(target).pathname;
+      }
+    } catch {
+      return target;
+    }
+
+    return target;
+  }
+
+  return '/';
+}
+
+function stripBase(pathname: string) {
+  const base = normalizeBase(import.meta.env.BASE_URL as string | undefined);
+
+  if (!pathname.startsWith('/')) {
+    pathname = `/${pathname}`;
+  }
+
+  if (!base) {
+    return pathname;
+  }
+
+  if (pathname === base) {
+    return '/';
+  }
+
+  if (pathname.startsWith(`${base}/`)) {
+    return pathname.slice(base.length);
+  }
+
+  return pathname;
+}
+
+export function getLocaleFromPath(target: string | URL | AstroGlobal): Locale {
+  const pathname = stripBase(toPathname(target));
+  const segments = pathname.replace(/^\//, '').split('/');
+  const maybeLocale = segments[0]?.toLowerCase();
+
+  return isLocale(maybeLocale) ? (maybeLocale as Locale) : defaultLocale;
+}
+
+export function getPathWithoutLocale(target: string | URL | AstroGlobal) {
+  const pathname = stripBase(toPathname(target));
+  const segments = pathname.split('/');
+  const maybeLocale = segments[1]?.toLowerCase();
+
+  if (isLocale(maybeLocale)) {
+    segments.splice(1, 1);
+  } else if (segments[0] && isLocale(segments[0].toLowerCase())) {
+    segments.splice(0, 1);
+  }
+
+  const normalized = segments.join('/') || '/';
+
+  if (normalized === '/') {
+    return '/';
+  }
+
+  return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function applyBase(path: string) {
+  const base = normalizeBase(import.meta.env.BASE_URL as string | undefined);
+
+  if (!base) {
+    return path;
+  }
+
+  return `${base}${path}`;
+}
+
+export function localizePath(target: string | URL | AstroGlobal, locale: Locale) {
+  const path = getPathWithoutLocale(target);
+  const localized = `/${locale}${path}`;
+
+  return applyBase(localized);
+}
+
+export function localizeUrl(target: string | URL | AstroGlobal, locale: Locale) {
+  let original: URL;
+
+  if (target instanceof URL) {
+    original = new URL(target.toString());
+  } else if (typeof target === 'object' && target !== null && 'url' in target) {
+    original = new URL((target as AstroGlobal).url.toString());
+  } else if (typeof target === 'string') {
+    if (target.startsWith('http://') || target.startsWith('https://')) {
+      original = new URL(target);
+    } else {
+      original = new URL(target, 'http://localhost');
+    }
+  } else {
+    original = new URL('http://localhost');
+  }
+
+  const localizedPath = localizePath(original, locale);
+  original.pathname = localizedPath;
+
+  return original;
+}


### PR DESCRIPTION
## Summary
- add i18n utility helpers that normalize paths, prepend the locale segment, and generate localized URLs with the correct base path
- update the navigation bar to consume the new helpers for primary links and the language switcher while highlighting the active locale
- enable Astro i18n configuration with prefixed locales and fallback behavior so translated routes resolve correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40b8bd56c8324a559760f2177fdb7