### PR TITLE
Allow MainLayout lang attribute to be configured

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -12,13 +12,14 @@ import "../styles/components.css"
 const {
   title = "My Astro Blog",
   description = "My musings about the Astro framework",
-	image,
-	robots,
-	project,
+  image,
+  robots,
+  project,
+  lang = "en",
 } = Astro.props;
 ---
 <!doctype html>
-<html lang="zh-tw" class="w-full h-full">
+<html lang={lang} class="w-full h-full">
 	<head>
 		<script is:inline>
 			// Process the theme setting before page conversion


### PR DESCRIPTION
## Summary
- default the layout's lang attribute to English and expose a prop to override it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6b56c19e8832488ab11c567a9334c