### PR TITLE
refactor: unify content cards

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -1,52 +1,25 @@
 ---
-import Card from "../common/Card.astro";
+import ContentCard from "../common/ContentCard.astro";
 import { slugify, formatDate } from "../../ts/utils";
 
 const { post } = Astro.props;
 const { title, description, date, image, tags, category } = post.data;
 
+const href = `/blog/${post.id}`;
 const imageUrl = image?.src || post.data.cover || "/assets/images/fallback-image.png";
 const imageAlt = image?.alt || title || "文章圖片";
+const tagLinks = (tags || []).map((tag: string) => ({
+  label: tag,
+  href: `/blog/tag/${slugify(tag)}`,
+}));
 ---
 
-<Card>
-  <a slot="image" href={`/blog/${post.id}`} class="block overflow-hidden relative">
-    <div class="aspect-video overflow-hidden">
-      <img
-        src={imageUrl}
-        alt={imageAlt}
-        class="object-cover w-full h-full transition-transform duration-500 group-hover:scale-105"
-      />
-    </div>
-
-    {category && (
-      <span class="label absolute top-4 left-4 px-3 py-1">
-        {category}
-      </span>
-    )}
-  </a>
-
-  <span slot="time">{formatDate(new Date(date))}</span>
-
-  <a slot="title" href={`/blog/${post.id}`} class="block">
-    <h2 class="text-xl font-bold mb-2 text-gray-900 dark:text-gray-100 group-hover:text-primary transition-colors">
-      {title}
-    </h2>
-  </a>
-
-  <p slot="description" class="text-gray-600 dark:text-gray-300 text-sm line-clamp-2 mb-4">
-    {description}
-  </p>
-
-  <div slot="actions">
-    {tags && tags.length > 0 && (
-      <div class="flex flex-wrap gap-2 mb-4">
-        {tags.slice(0, 3).map((tag: string) => (
-          <a href={`/blog/tag/${slugify(tag)}`} class="text-xs px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
-            #{tag}
-          </a>
-        ))}
-      </div>
-    )}
-  </div>
-</Card>
+<ContentCard
+  href={href}
+  title={title}
+  time={formatDate(new Date(date))}
+  description={description}
+  image={{ src: imageUrl, alt: imageAlt }}
+  category={category}
+  tags={tagLinks}
+/>

--- a/src/components/common/ContentCard.astro
+++ b/src/components/common/ContentCard.astro
@@ -1,0 +1,114 @@
+---
+import Card from "./Card.astro";
+
+interface Tag {
+  label: string;
+  href: string;
+}
+
+interface Cta {
+  label: string;
+  href: string;
+}
+
+interface ImageMeta {
+  src: string;
+  alt: string;
+}
+
+interface Props {
+  href: string;
+  title: string;
+  time?: string;
+  description?: string;
+  image: ImageMeta;
+  category?: string;
+  tags?: Tag[];
+  cta?: Cta;
+  class?: string;
+}
+
+const {
+  href,
+  title,
+  time,
+  description,
+  image,
+  category,
+  tags = [],
+  cta,
+  class: customClass = "",
+} = Astro.props as Props;
+---
+
+<Card class={customClass}>
+  <a
+    slot="image"
+    href={href}
+    class="block relative overflow-hidden"
+  >
+    <div class="aspect-video overflow-hidden">
+      <img
+        src={image.src}
+        alt={image.alt}
+        class="object-cover w-full h-full transition-transform duration-500 group-hover:scale-105"
+        loading="lazy"
+      />
+    </div>
+
+    {category && (
+      <span class="label absolute top-4 left-4 px-3 py-1">
+        {category}
+      </span>
+    )}
+  </a>
+
+  {time && <span slot="time">{time}</span>}
+
+  <a slot="title" href={href} class="block">
+    <h2 class="text-xl font-bold mb-2 text-gray-900 dark:text-gray-100 group-hover:text-primary transition-colors">
+      {title}
+    </h2>
+  </a>
+
+  {description && (
+    <p slot="description" class="text-gray-600 dark:text-gray-300 text-sm line-clamp-2 mb-4">
+      {description}
+    </p>
+  )}
+
+  <div slot="actions">
+    {tags.length > 0 && (
+      <div class="flex flex-wrap gap-2 mb-4">
+        {tags.slice(0, 3).map((tag) => (
+          <a
+            href={tag.href}
+            class="text-xs px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+          >
+            #{tag.label}
+          </a>
+        ))}
+      </div>
+    )}
+
+    {cta && (
+      <a
+        href={cta.href}
+        class="inline-flex items-center px-4 py-2 bg-black dark:bg-white text-white dark:text-black rounded-lg hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors font-medium text-sm"
+      >
+        {cta.label}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4 ml-1 transition-transform group-hover:translate-x-1"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+        </svg>
+      </a>
+    )}
+  </div>
+</Card>

--- a/src/components/project/ProjectCard.astro
+++ b/src/components/project/ProjectCard.astro
@@ -1,5 +1,5 @@
 ---
-import Card from "../common/Card.astro";
+import ContentCard from "../common/ContentCard.astro";
 import { slugify, formatDate } from "../../ts/utils";
 import type { CollectionEntry } from "astro:content";
 
@@ -7,61 +7,23 @@ interface Props {
   project: CollectionEntry<"projects">;
 }
 
-const { project } = Astro.props;
+const { project } = Astro.props as Props;
 const { title, description, date, tags, cover } = project.data;
 const projectId = project.id || slugify(title);
+const href = `/project/${projectId}`;
+const imageUrl = cover || "/assets/images/fallback-image.png";
+const tagLinks = (tags || []).map((tag: string) => ({
+  label: tag,
+  href: `/project/tag/${slugify(tag)}`,
+}));
 ---
 
-<Card>
-  <a slot="image" href={`/project/${projectId}`} class="block overflow-hidden rounded-t-lg relative">
-    <div class="aspect-video overflow-hidden">
-      <img
-        src={cover}
-        alt={title}
-        class="object-cover w-full h-full transition-transform duration-500 group-hover:scale-110"
-      />
-    </div>
-  </a>
-
-  <span slot="time">{formatDate(new Date(date))}</span>
-
-  <a slot="title" href={`/project/${projectId}`} class="block">
-    <h2 class="text-xl font-bold mb-2 text-gray-900 dark:text-gray-100 group-hover:text-primary transition-colors">
-      {title}
-    </h2>
-  </a>
-
-  <p slot="description" class="text-gray-600 dark:text-gray-300 text-sm line-clamp-2 mb-4">
-    {description}
-  </p>
-
-  <div slot="actions">
-    {tags && tags.length > 0 && (
-      <div class="flex flex-wrap gap-2 mb-4">
-        {tags.slice(0, 3).map((tag: string) => (
-          <a href={`/project/tag/${slugify(tag)}`} class="text-xs px-3 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
-            #{tag}
-          </a>
-        ))}
-      </div>
-    )}
-
-    <a
-      href={`/project/${projectId}`}
-      class="inline-flex items-center px-4 py-2 bg-black dark:bg-white text-white dark:text-black rounded-lg hover:bg-gray-800 dark:hover:bg-gray-100 transition-colors font-medium text-sm"
-    >
-      查看專案
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-4 w-4 ml-1 transition-transform group-hover:translate-x-1"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-      </svg>
-    </a>
-  </div>
-</Card>
+<ContentCard
+  href={href}
+  title={title}
+  time={formatDate(new Date(date))}
+  description={description}
+  image={{ src: imageUrl, alt: title }}
+  tags={tagLinks}
+  cta={{ label: "查看專案", href }}
+/>


### PR DESCRIPTION
## Summary
- add a shared ContentCard wrapper that consolidates the common layout for content previews
- update blog and project cards to prepare their data and render through the shared component
- normalize card styling and ensure a fallback image is provided for projects

## Testing
- npm run build
- npm run dev -- --host 0.0.0.0 --port 3000


------
https://chatgpt.com/codex/tasks/task_e_68dfe9a482bc8324ac00e5ff674b661e