### PR TITLE
Enhance blog TOC with nested structure and highlighting

### DIFF
--- a/src/components/common/TableOfContentsList.astro
+++ b/src/components/common/TableOfContentsList.astro
@@ -1,0 +1,38 @@
+---
+interface TocItem {
+  depth: number;
+  slug: string;
+  text: string;
+  children: TocItem[];
+}
+
+interface TableOfContentsListProps {
+  items: TocItem[];
+  isRoot?: boolean;
+}
+
+const { items, isRoot = true } = Astro.props as TableOfContentsListProps;
+---
+{items.length > 0 && (
+  <ul
+    class:list={{
+      'space-y-1': true,
+      'toc-list': isRoot,
+      'toc-sublist': !isRoot,
+    }}
+  >
+    {items.map((item) => (
+      <li class="toc-item" data-depth={item.depth}>
+        <a
+          href={`#${item.slug}`}
+          class="toc-link block rounded-md px-2 py-1 text-xs text-text-secondary transition-colors"
+        >
+          {item.text}
+        </a>
+        {item.children.length > 0 && (
+          <Component this={Astro.self} items={item.children} isRoot={false} />
+        )}
+      </li>
+    ))}
+  </ul>
+)}

--- a/src/pages/blog/[post].astro
+++ b/src/pages/blog/[post].astro
@@ -1,5 +1,7 @@
 ---
+import type { MarkdownHeading } from 'astro';
 import { type CollectionEntry } from 'astro:content';
+import TableOfContentsList from '../../components/common/TableOfContentsList.astro';
 import PostLayout from '../../layouts/PostLayout.astro';
 import CategoryList from '../../components/common/CategoryList.astro';
 import RelatedItems from '../../components/common/RelatedItems.astro';
@@ -27,7 +29,43 @@ if (!post) {
   return Astro.redirect('/404');
 }
 
+interface TocItem {
+  depth: number;
+  slug: string;
+  text: string;
+  children: TocItem[];
+}
+
+const buildTocTree = (items: MarkdownHeading[]): TocItem[] => {
+  const root: TocItem[] = [];
+  const stack: TocItem[] = [];
+
+  for (const item of items) {
+    const current: TocItem = {
+      depth: item.depth,
+      slug: item.slug,
+      text: item.text,
+      children: [],
+    };
+
+    while (stack.length > 0 && stack[stack.length - 1].depth >= current.depth) {
+      stack.pop();
+    }
+
+    if (stack.length === 0) {
+      root.push(current);
+    } else {
+      stack[stack.length - 1].children.push(current);
+    }
+
+    stack.push(current);
+  }
+
+  return root;
+};
+
 const { Content, headings } = await post.render();
+const tocTree = buildTocTree(headings);
 ---
 
 <PostLayout post={post}>
@@ -131,18 +169,11 @@ const { Content, headings } = await post.render();
             >
               <div>
                 <nav id="tableOfContents" class="table-of-contents">
-                  <ul class="space-y-1">
-                    {headings.map(heading => (
-                      <li class={`pl-${(heading.depth - 1) * 4} hover:bg-background-tertiary transition-colors duration-300 px-2 py-1 rounded-md`}>
-                        <a
-                          href={`#${heading.slug}`}
-                          class="block hover:text-primary transition-colors text-xs text-text-secondary"
-                        >
-                          {heading.text}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
+                  {tocTree.length > 0 ? (
+                    <TableOfContentsList items={tocTree} />
+                  ) : (
+                    <p class="pl-2 text-xs text-text-muted">No sections available</p>
+                  )}
                 </nav>
               </div>
             </div>
@@ -221,6 +252,73 @@ const { Content, headings } = await post.render();
       }
     });
   });
+
+  const tocLinks = Array.from(document.querySelectorAll('#tableOfContents a'));
+  const headingMap = new Map();
+
+  const clearActiveState = () => {
+    document.querySelectorAll('#tableOfContents .toc-link-active').forEach((el) => {
+      el.classList.remove('toc-link-active');
+    });
+    document.querySelectorAll('#tableOfContents .toc-item-active').forEach((el) => {
+      el.classList.remove('toc-item-active');
+    });
+  };
+
+  const setActiveLink = (link) => {
+    if (!link) return;
+    clearActiveState();
+    link.classList.add('toc-link-active');
+
+    let currentItem = link.closest('.toc-item');
+    while (currentItem) {
+      currentItem.classList.add('toc-item-active');
+      const parentList = currentItem.parentElement;
+      currentItem = parentList ? parentList.closest('.toc-item') : null;
+    }
+  };
+
+  tocLinks.forEach((link) => {
+    const targetId = link.getAttribute('href')?.replace(/^#/, '');
+    if (!targetId) return;
+
+    const decodedId = decodeURIComponent(targetId);
+    const target = document.getElementById(decodedId);
+
+    if (target) {
+      headingMap.set(target, link);
+    }
+
+    link.addEventListener('click', () => {
+      setActiveLink(link);
+    });
+  });
+
+  if (headingMap.size > 0) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const link = headingMap.get(entry.target);
+          if (link) {
+            setActiveLink(link);
+          }
+        });
+      },
+      {
+        rootMargin: '-40% 0px -40% 0px',
+        threshold: [0, 0.1, 0.3, 0.5, 1],
+      }
+    );
+
+    headingMap.forEach((_, heading) => observer.observe(heading));
+
+    window.addEventListener('beforeunload', () => observer.disconnect());
+  }
+
+  if (tocLinks.length > 0) {
+    setActiveLink(tocLinks[0]);
+  }
 </script>
 
 <style>
@@ -249,6 +347,30 @@ const { Content, headings } = await post.render();
     grid-template-rows: 0fr;
     opacity: 0;
     pointer-events: none;
+  }
+
+  .table-of-contents .toc-item {
+    position: relative;
+  }
+
+  .table-of-contents .toc-sublist {
+    margin-top: 0.25rem;
+    padding-left: 0.75rem;
+    border-left: 1px solid var(--color-border);
+  }
+
+  .table-of-contents .toc-item-active > .toc-link {
+    background-color: var(--color-background-tertiary);
+  }
+
+  .table-of-contents .toc-item-active > .toc-link,
+  .table-of-contents .toc-link-active {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  .table-of-contents .toc-link:hover {
+    color: var(--color-primary);
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- build a reusable table-of-contents list component that renders nested heading hierarchies
- update the blog post layout to generate a heading tree and display it with the new component
- add scroll-based logic and styling to highlight the active section and its ancestors in the sidebar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e14395e4e483248019d27c186f71e6